### PR TITLE
fix: Remove SelectionEntry.CategoryEntryId property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `NodeFactory` in `WarHub.ArmouryModel.Source` namespace was rewritten to provide
   much more defaults, use other Nodes as value providers, and add more methods ([#58]).
 
+## Removed
+* `SelectionEntryNode.CategoryEntryId` property was removed. It was a leftover from old format, pre-2.01 ([#59]).
+
 [#47]: https://github.com/WarHub/wham/pull/47
 [#58]: https://github.com/WarHub/wham/pull/58
+[#59]: https://github.com/WarHub/wham/pull/59
 
 ## [0.6.17] - 2019-08-16
 

--- a/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
+++ b/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
@@ -442,7 +442,6 @@ namespace WarHub.ArmouryModel.Source
                 isHidden: false,
                 collective: false,
                 import: true,
-                categoryEntryId: null,
                 type: SelectionEntryKind.Upgrade);
         }
 

--- a/src/WarHub.ArmouryModel.Source/SelectionEntryCore.cs
+++ b/src/WarHub.ArmouryModel.Source/SelectionEntryCore.cs
@@ -7,9 +7,6 @@ namespace WarHub.ArmouryModel.Source
     [XmlType("selectionEntry")]
     public partial class SelectionEntryCore : SelectionEntryBaseCore
     {
-        [XmlAttribute("categoryEntryId")]
-        public string CategoryEntryId { get; }
-
         [XmlAttribute("type")]
         public SelectionEntryKind Type { get; }
 


### PR DESCRIPTION
dropped in 2.01, left over

closes #57