### PR TITLE
fix: add SEs, SEGs and ELs to EntryLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Support for BattleScribe v2.03 data format ([#47])
 * "Latest" channel (folder) for `Catalogue.xsd`.
 * `wham --info` command that displays more detailed program info ([#64]).
+* EntryLink now has `SelectionEntries`, `SelectionEntryGroups` and `EntryLinks` lists ([#77]).
 
 ### Changed
 * Current version of schema changed to v2.03 (latest)
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Cores and Nodes' With and Update methods now check for equality of old and new,
   and when they're equal, return current instance ([#75]).
 * `SourceRewriter` implementation fixed to actually work ([#75]).
+* EntryLink now inherits from SelectionEntryBase instead of EntryBase ([#77]).
 
 ## Removed
 * `SelectionEntryNode.CategoryEntryId` property was removed. It was a leftover from old format, pre-2.01 ([#59]).
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#63]: https://github.com/WarHub/wham/pull/63
 [#64]: https://github.com/WarHub/wham/pull/64
 [#75]: https://github.com/WarHub/wham/pull/75
+[#77]: https://github.com/WarHub/wham/pull/77
 
 ## [0.6.17] - 2019-08-16
 

--- a/src/WarHub.ArmouryModel.Source/EntryLinkCore.cs
+++ b/src/WarHub.ArmouryModel.Source/EntryLinkCore.cs
@@ -5,37 +5,13 @@ namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
     [XmlType("entryLink")]
-    public partial class EntryLinkCore : EntryBaseCore
+    public partial class EntryLinkCore : SelectionEntryBaseCore
     {
-        [XmlAttribute("collective")]
-        public bool Collective { get; }
-
-        [XmlAttribute("import")]
-        public bool Import { get; }
-
         [XmlAttribute("targetId")]
         public string TargetId { get; }
 
         [XmlAttribute("type")]
         public EntryLinkKind Type { get; }
-
-        [XmlArray("constraints")]
-        public ImmutableArray<ConstraintCore> Constraints { get; }
-
-        [XmlArray("profiles")]
-        public ImmutableArray<ProfileCore> Profiles { get; }
-
-        [XmlArray("rules")]
-        public ImmutableArray<RuleCore> Rules { get; }
-
-        [XmlArray("infoGroups")]
-        public ImmutableArray<InfoGroupCore> InfoGroups { get; }
-
-        [XmlArray("infoLinks")]
-        public ImmutableArray<InfoLinkCore> InfoLinks { get; }
-
-        [XmlArray("categoryLinks")]
-        public ImmutableArray<CategoryLinkCore> CategoryLinks { get; }
 
         [XmlArray("costs")]
         public ImmutableArray<CostCore> Costs { get; }

--- a/src/dataformat/xml/schema/latest/Catalogue.xsd
+++ b/src/dataformat/xml/schema/latest/Catalogue.xsd
@@ -3,7 +3,7 @@
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="http://www.battlescribe.net/schema/catalogueSchema"
            targetNamespace="http://www.battlescribe.net/schema/catalogueSchema">
-  
+
   <!--schema for BattleScribe [version 2.03, (c) Jon Taylor] datafiles (catalogues and game systems)-->
   <!--schema file author: Amadeusz Sadowski-->
   <!--for game system, replace 'xmlns:tns' and 'targetNamespace' values with http://www.battlescribe.net/schema/gameSystemSchema -->
@@ -13,7 +13,7 @@
   <xs:simpleType name="idtype">
     <xs:restriction base="xs:string" />
   </xs:simpleType>
-  
+
   <!--publication-->
   <xs:complexType name="Publication">
     <xs:attribute name="id" type="tns:idtype" use="required" />
@@ -25,12 +25,12 @@
       <xs:element name="publication" type="tns:Publication" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <xs:attributeGroup name="PublicationRefAttGroup">
     <xs:attribute name="publicationId" type="tns:idtype" />
     <xs:attribute name="page" type="xs:string" />
   </xs:attributeGroup>
-  
+
   <!--characteristic type-->
   <xs:complexType name="CharacteristicType">
     <xs:attribute name="id" type="tns:idtype" use="required" />
@@ -57,7 +57,7 @@
       <xs:element name="profileType" type="tns:ProfileType" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <!--cost type-->
   <xs:complexType name="CostType">
     <xs:attribute name="id" type="tns:idtype" use="required" />
@@ -70,7 +70,7 @@
       <xs:element name="costType" type="tns:CostType" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <!--entry base-->
   <xs:complexType name="EntryBase">
     <xs:sequence>
@@ -92,7 +92,7 @@
       <xs:element name="infoLinks" type="tns:InfoLinkList" minOccurs="0" />
     </xs:sequence>
   </xs:group>
-  
+
   <!--characteristic-->
   <xs:complexType name="Characteristic">
     <xs:simpleContent>
@@ -199,7 +199,7 @@
       <xs:element name="forceEntry" type="tns:ForceEntry" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <!--costs-->
   <xs:complexType name="Cost">
     <xs:attribute name="name" type="xs:string" use="required" />
@@ -244,7 +244,7 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  
+
   <!--selection entry-->
   <xs:complexType name="SelectionEntry">
     <xs:complexContent>
@@ -285,7 +285,7 @@
       <xs:element name="selectionEntryGroup" type="tns:SelectionEntryGroup" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <!--info link-->
   <xs:complexType name="InfoLink">
     <xs:complexContent>
@@ -354,15 +354,10 @@
   <!--entry link-->
   <xs:complexType name="EntryLink">
     <xs:complexContent>
-      <xs:extension base="tns:EntryBase">
+      <xs:extension base="tns:SelectionEntryBase">
         <xs:sequence>
-          <xs:element name="constraints" type="tns:ConstraintList" minOccurs="0" />
-          <xs:group ref="tns:InfoNodeGroup" />
-          <xs:element name="categoryLinks" type="tns:CategoryLinkList" minOccurs="0" />
           <xs:element name="costs" type="tns:CostList" minOccurs="0" />
         </xs:sequence>
-        <xs:attribute name="collective" type="xs:boolean" default="false" />
-        <xs:attribute name="import" type="xs:boolean" default="false" />
         <xs:attribute name="targetId" type="tns:idtype" use="required" />
         <xs:attribute name="type" type="tns:EntryLinkKind" use="required" />
       </xs:extension>
@@ -446,7 +441,7 @@
       <xs:enumeration value="unset-primary" />
     </xs:restriction>
   </xs:simpleType>
-  
+
   <!--modifier group-->
   <xs:complexType name="ModifierGroup">
     <xs:sequence>
@@ -473,14 +468,14 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  
+
   <xs:complexType name="RepeatList">
     <xs:sequence>
       <xs:element name="repeat" type="tns:Repeat" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 
-  <!--condition--> 
+  <!--condition-->
   <xs:complexType name="Condition">
     <xs:complexContent>
       <xs:extension base="tns:SelectorBase">
@@ -530,7 +525,7 @@
       <xs:enumeration value="or" />
     </xs:restriction>
   </xs:simpleType>
-  
+
   <!--roster element base-->
   <xs:complexType name="RosterElementBase">
     <xs:sequence>
@@ -543,7 +538,7 @@
     <xs:attribute name="entryGroupId" type="tns:idtype" />
     <xs:attributeGroup ref="tns:PublicationRefAttGroup" />
   </xs:complexType>
-  
+
   <!--force-->
   <xs:complexType name="Force">
     <xs:complexContent>
@@ -581,7 +576,7 @@
       <xs:element name="category" type="tns:Category" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <!--selection-->
   <xs:complexType name="Selection">
     <xs:complexContent>
@@ -602,7 +597,7 @@
       <xs:element name="selection" type="tns:Selection" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
-  
+
   <!--catalogue base-->
   <xs:complexType name="CatalogueBase">
     <xs:sequence>

--- a/src/dataformat/xml/schema/v2_02/Catalogue.xsd
+++ b/src/dataformat/xml/schema/v2_02/Catalogue.xsd
@@ -352,13 +352,7 @@
   <!--entry link-->
   <xs:complexType name="EntryLink">
     <xs:complexContent>
-      <xs:extension base="tns:EntryBase">
-        <xs:sequence>
-          <xs:element name="constraints" type="tns:ConstraintList" minOccurs="0" />
-          <xs:group ref="tns:InfoNodeGroup" />
-          <xs:element name="categoryLinks" type="tns:CategoryLinkList" minOccurs="0" />
-        </xs:sequence>
-        <xs:attribute name="collective" type="xs:boolean" default="false" />
+      <xs:extension base="tns:SelectionEntryBase">
         <xs:attribute name="targetId" type="tns:idtype" use="required" />
         <xs:attribute name="type" type="tns:EntryLinkKind" use="required" />
       </xs:extension>

--- a/src/dataformat/xml/schema/v2_03/Catalogue.xsd
+++ b/src/dataformat/xml/schema/v2_03/Catalogue.xsd
@@ -354,15 +354,10 @@
   <!--entry link-->
   <xs:complexType name="EntryLink">
     <xs:complexContent>
-      <xs:extension base="tns:EntryBase">
+      <xs:extension base="tns:SelectionEntryBase">
         <xs:sequence>
-          <xs:element name="constraints" type="tns:ConstraintList" minOccurs="0" />
-          <xs:group ref="tns:InfoNodeGroup" />
-          <xs:element name="categoryLinks" type="tns:CategoryLinkList" minOccurs="0" />
           <xs:element name="costs" type="tns:CostList" minOccurs="0" />
         </xs:sequence>
-        <xs:attribute name="collective" type="xs:boolean" default="false" />
-        <xs:attribute name="import" type="xs:boolean" default="false" />
         <xs:attribute name="targetId" type="tns:idtype" use="required" />
         <xs:attribute name="type" type="tns:EntryLinkKind" use="required" />
       </xs:extension>

--- a/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_01Tests.cs
+++ b/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_01Tests.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using FluentAssertions;
+using Xunit;
+using static WarHub.ArmouryModel.Source.NodeFactory;
+
+namespace WarHub.ArmouryModel.Source.Tests.DataFormat
+{
+    public class XmlSchema2_01Tests
+    {
+
+        [Fact]
+        public void EntryLink_can_contain_entries()
+        {
+            var link = EntryLink(SelectionEntry());
+            var result = link
+                .AddSelectionEntries(
+                    SelectionEntry())
+                .AddSelectionEntryGroups(
+                    SelectionEntryGroup())
+                .AddEntryLinks(
+                    EntryLink(
+                        SelectionEntry()));
+            new IListNode[]
+            {
+                result.SelectionEntries,
+                result.SelectionEntryGroups,
+                result.EntryLinks
+            }
+                .Select(x => x.NodeList.Count)
+                .Should()
+                .AllBeEquivalentTo(1);
+        }
+    }
+}

--- a/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_01Tests.cs
+++ b/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_01Tests.cs
@@ -7,7 +7,6 @@ namespace WarHub.ArmouryModel.Source.Tests.DataFormat
 {
     public class XmlSchema2_01Tests
     {
-
         [Fact]
         public void EntryLink_can_contain_entries()
         {

--- a/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_03Tests.cs
+++ b/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_03Tests.cs
@@ -45,5 +45,13 @@ namespace WarHub.ArmouryModel.Source.Tests.DataFormat
 
             modifier.Type.Should().Be(kindValue);
         }
+
+        [Fact]
+        public void EntryLink_can_contain_costs()
+        {
+            var link = EntryLink(SelectionEntry());
+            var result = link.AddCosts(Cost(CostType(), 1));
+            result.Costs[0].Value.Should().Be(1);
+        }
     }
 }


### PR DESCRIPTION
This is done via changing inheritance: EntryLink now inherits SelectionEntryBase instead of EntryBase.

closes #76