### PR TITLE
feat: Add fields for schema parity with BattleScribe v2.03

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # all history
-      - name: Read .NET Core SDK version
-        id: globaljson
-        shell: pwsh
-        run: |
-          dotnet --version
-          if ($LASTEXITCODE -ne 0) { # if dotnet didn't find version required by globaljson, it exits with non-0 code
-            Write-Host "::set-output name=version::$((Get-Content global.json -Raw | ConvertFrom-Json).sdk.version)"
-          }
       - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ steps.globaljson.outputs.version }}
       - run: dotnet --info
       - run: dotnet tool restore
       - run: dotnet nbgv get-version

--- a/.github/workflows/deploy-command.yml
+++ b/.github/workflows/deploy-command.yml
@@ -23,17 +23,7 @@ jobs:
         with:
           fetch-depth: 0 # all history
           ref: ${{ github.event.client_payload.slash_command.ref }}
-      - name: Read .NET Core SDK version
-        id: globaljson
-        shell: pwsh
-        run: |
-          dotnet --version
-          if ($LASTEXITCODE -ne 0) { # if dotnet didn't find version required by globaljson, it exits with non-0 code
-            Write-Host "::set-output name=version::$((Get-Content global.json -Raw | ConvertFrom-Json).sdk.version)"
-          }
       - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ steps.globaljson.outputs.version }}
       - run: dotnet --info
       - run: dotnet tool restore
       - run: dotnet nbgv get-version

--- a/.github/workflows/tag-command.yml
+++ b/.github/workflows/tag-command.yml
@@ -20,17 +20,7 @@ jobs:
         with:
           fetch-depth: 0 # all history
           ref: ${{ github.event.client_payload.slash_command.ref }}
-      - name: Read .NET Core SDK version
-        id: globaljson
-        shell: pwsh
-        run: |
-          dotnet --version
-          if ($LASTEXITCODE -ne 0) { # if dotnet didn't find version required by globaljson, it exits with non-0 code
-            Write-Host "::set-output name=version::$((Get-Content global.json -Raw | ConvertFrom-Json).sdk.version)"
-          }
       - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ steps.globaljson.outputs.version }}
       - run: dotnet --info
       - run: dotnet tool restore
       - name: Add and push version tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added some base classes:
+    - added QueryFilteredBase (QueryBase with ChildId), inherits from QueryBase
+    - added SelectionParentBase, base of Force and Selection
+    - added ModifierBase, base of Modifier and ModifierGroup
+- Added descriptive comments to ModifierKind
+- Added RosterTag type
+- Added missing fields to be fully 2.03 schema compliant:
+    - added CostType.Hidden
+    - added ModifierGroup.ModifierGroups
+    - added many fields to Publication:
+      - ShortName
+      - Publisher
+      - PublicationDate
+      - PublisherUrl
+    - added CustomNotes and Tags to Roster
+    - added CustomName and CustomNotes to RosterElementBase
+
+### Changed
+- CharacteristicType now inherits Commentable
+- renamed SelectorBase to QueryBase
+- BSv2.03 schema with the above changes
+
+
 ## [0.10.0] - 2020-06-03
 
 ### Added

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.201",
+    "version": "3.1.302",
     "rollForward": "feature"
   },
   "msbuild-sdks": {

--- a/src/WarHub.ArmouryModel.Source/ConditionCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ConditionCore.cs
@@ -4,14 +4,8 @@ namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
     [XmlType("condition")]
-    public sealed partial class ConditionCore : SelectorBaseCore
+    public sealed partial class ConditionCore : QueryFilteredBaseCore
     {
-        /// <summary>
-        /// Changes the query to filter by this value.
-        /// </summary>
-        [XmlAttribute("childId")]
-        public string? ChildId { get; }
-
         [XmlAttribute("type")]
         public ConditionKind Type { get; }
     }

--- a/src/WarHub.ArmouryModel.Source/ConstraintCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ConstraintCore.cs
@@ -4,7 +4,7 @@ namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
     [XmlType("constraint")]
-    public sealed partial class ConstraintCore : SelectorBaseCore
+    public sealed partial class ConstraintCore : QueryBaseCore
     {
         [XmlAttribute("id")]
         public string? Id { get; }

--- a/src/WarHub.ArmouryModel.Source/CostTypeCore.cs
+++ b/src/WarHub.ArmouryModel.Source/CostTypeCore.cs
@@ -14,5 +14,8 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlAttribute("defaultCostLimit")]
         public decimal DefaultCostLimit { get; }
+
+        [XmlAttribute("hidden")]
+        public bool Hidden { get; }
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ForceCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ForceCore.cs
@@ -5,7 +5,7 @@ namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
     [XmlType("force")]
-    public sealed partial class ForceCore : RosterElementBaseCore
+    public sealed partial class ForceCore : SelectionParentBaseCore
     {
         [XmlAttribute("catalogueId")]
         public string? CatalogueId { get; }
@@ -15,9 +15,6 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlAttribute("catalogueName")]
         public string? CatalogueName { get; }
-
-        [XmlArray("selections")]
-        public ImmutableArray<SelectionCore> Selections { get; }
 
         [XmlArray("publications")]
         public ImmutableArray<PublicationCore> Publications { get; }

--- a/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
+++ b/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
@@ -29,7 +29,7 @@ namespace WarHub.ArmouryModel.Source
         /// <summary>
         /// Generates new name via prepending caller name with "New ".
         /// </summary>
-        private static string NewName([CallerMemberName]string? callerMember = null)
+        private static string NewName([CallerMemberName] string? callerMember = null)
             => "New " + callerMember;
 
         public static CatalogueNode Catalogue(GamesystemNode gamesystem, string? name = null, string? id = null)
@@ -64,11 +64,13 @@ namespace WarHub.ArmouryModel.Source
         {
             return Category(
                 id: id ?? NewId(),
-                categoryEntry.Name ?? NewName(),
-                categoryEntry.Id,
+                name: categoryEntry.Name ?? NewName(),
+                entryId: categoryEntry.Id,
                 entryGroupId: null,
-                categoryEntry.PublicationId,
-                categoryEntry.Page,
+                customName: null,
+                customNotes: null,
+                publicationId: categoryEntry.PublicationId,
+                page: categoryEntry.Page,
                 primary: false);
         }
 
@@ -107,6 +109,7 @@ namespace WarHub.ArmouryModel.Source
         public static CharacteristicTypeNode CharacteristicType(string? name = null)
         {
             return CharacteristicType(
+                comment: null,
                 id: NewId(),
                 name: name ?? NewName());
         }
@@ -181,7 +184,8 @@ namespace WarHub.ArmouryModel.Source
                 comment: null,
                 id: NewId(),
                 name: name ?? NewName(),
-                defaultCostLimit: defaultCostLimit);
+                defaultCostLimit: defaultCostLimit,
+                hidden: false);
         }
 
         public static DatablobNode Datablob()
@@ -264,6 +268,8 @@ namespace WarHub.ArmouryModel.Source
                 name: forceEntry.Name ?? NewName(),
                 entryId: forceEntry.Id,
                 entryGroupId: null,
+                customName: null,
+                customNotes: null,
                 publicationId: forceEntry.PublicationId,
                 page: forceEntry.Page,
                 catalogueId: catalogue.Id,
@@ -404,7 +410,11 @@ namespace WarHub.ArmouryModel.Source
             return Publication(
                 comment: null,
                 id: NewId(),
-                name: name ?? NewName());
+                name: name ?? NewName(),
+                shortName: null,
+                publisher: null,
+                publicationDate: null,
+                publisherUrl: null);
         }
 
         public static RepeatNode Repeat(
@@ -435,7 +445,8 @@ namespace WarHub.ArmouryModel.Source
                 battleScribeVersion: RootElement.Roster.Info().CurrentVersion.BattleScribeString,
                 gameSystemId: gamesystem.Id,
                 gameSystemName: gamesystem.Name,
-                gameSystemRevision: gamesystem.Revision);
+                gameSystemRevision: gamesystem.Revision,
+                customNotes: null);
         }
 
         public static RuleNode Rule(string? name = null, string? id = null, string? description = null)
@@ -461,6 +472,8 @@ namespace WarHub.ArmouryModel.Source
                 name: selectionEntry.Name ?? NewName(),
                 entryId: entryId,
                 entryGroupId: entryGroupId,
+                customName: null,
+                customNotes: null,
                 publicationId: selectionEntry.PublicationId,
                 page: selectionEntry.Page,
                 number: 1,

--- a/src/WarHub.ArmouryModel.Source/Foundation/SourceKind.cs
+++ b/src/WarHub.ArmouryModel.Source/Foundation/SourceKind.cs
@@ -70,6 +70,8 @@
 
         Selection, SelectionList,
 
+        RosterTag, RosterTagList,
+
         // top elements
         Catalogue, CatalogueList,
 

--- a/src/WarHub.ArmouryModel.Source/Foundation/SourceNode.cs
+++ b/src/WarHub.ArmouryModel.Source/Foundation/SourceNode.cs
@@ -123,7 +123,7 @@ namespace WarHub.ArmouryModel.Source
         /// <returns>First ancestor (or self) that satisfies both conditions.</returns>
         public TNode? FirstAncestorOrSelf<TNode>(Func<TNode, bool>? predicate = null) where TNode : class
         {
-            SourceNode? node = this;
+            var node = this;
             if (predicate is null)
             {
                 while (node != null)
@@ -193,7 +193,7 @@ namespace WarHub.ArmouryModel.Source
             {
                 yield return this;
             }
-            SourceNode? node = this;
+            var node = this;
             while ((node = node.Parent) != null)
             {
                 yield return node;

--- a/src/WarHub.ArmouryModel.Source/ModifierBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ModifierBaseCore.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Immutable;
+using System.Xml.Serialization;
+
+namespace WarHub.ArmouryModel.Source
+{
+    [WhamNodeCore]
+    public abstract partial class ModifierBaseCore : CommentableCore
+    {
+        [XmlArray("repeats")]
+        public ImmutableArray<RepeatCore> Repeats { get; }
+
+        [XmlArray("conditions")]
+        public ImmutableArray<ConditionCore> Conditions { get; }
+
+        [XmlArray("conditionGroups")]
+        public ImmutableArray<ConditionGroupCore> ConditionGroups { get; }
+    }
+}

--- a/src/WarHub.ArmouryModel.Source/ModifierCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ModifierCore.cs
@@ -1,11 +1,10 @@
-﻿using System.Collections.Immutable;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
 namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
     [XmlType("modifier")]
-    public sealed partial class ModifierCore : CommentableCore
+    public sealed partial class ModifierCore : ModifierBaseCore
     {
         [XmlAttribute("type")]
         public ModifierKind Type { get; }
@@ -15,14 +14,5 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlAttribute("value")]
         public string? Value { get; }
-
-        [XmlArray("repeats")]
-        public ImmutableArray<RepeatCore> Repeats { get; }
-
-        [XmlArray("conditions")]
-        public ImmutableArray<ConditionCore> Conditions { get; }
-
-        [XmlArray("conditionGroups")]
-        public ImmutableArray<ConditionGroupCore> ConditionGroups { get; }
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ModifierGroupCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ModifierGroupCore.cs
@@ -5,18 +5,12 @@ namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
     [XmlType("modifierGroup")]
-    public sealed partial class ModifierGroupCore : CommentableCore
+    public sealed partial class ModifierGroupCore : ModifierBaseCore
     {
-        [XmlArray("repeats")]
-        public ImmutableArray<RepeatCore> Repeats { get; }
-
-        [XmlArray("conditions")]
-        public ImmutableArray<ConditionCore> Conditions { get; }
-
-        [XmlArray("conditionGroups")]
-        public ImmutableArray<ConditionGroupCore> ConditionGroups { get; }
-
         [XmlArray("modifiers")]
         public ImmutableArray<ModifierCore> Modifiers { get; }
+
+        [XmlArray("modifierGroups")]
+        public ImmutableArray<ModifierGroupCore> ModifierGroups { get; }
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ModifierKind.cs
+++ b/src/WarHub.ArmouryModel.Source/ModifierKind.cs
@@ -4,27 +4,59 @@ namespace WarHub.ArmouryModel.Source
 {
     public enum ModifierKind
     {
+        /// <summary>
+        /// Modifies the target by replacing its value with Modifier's value.
+        /// Usable on Number, String, Boolean and Category fields.
+        /// </summary>
         [XmlEnum("set")]
         Set,
 
+        /// <summary>
+        /// Modifies the target by increasing its value by Modifier's value.
+        /// Usable on Number fields, and String fields containing a number.
+        /// </summary>
         [XmlEnum("increment")]
         Increment,
 
+        /// <summary>
+        /// Modifies the target by decreasing its value by Modifier's value.
+        /// Usable on Number fields, and String fields containing a number.
+        /// </summary>
         [XmlEnum("decrement")]
         Decrement,
 
+        /// <summary>
+        /// Modifies the target by appending its value with Modifier's value.
+        /// Usable on String fields.
+        /// </summary>
         [XmlEnum("append")]
         Append,
 
+        /// <summary>
+        /// Modifies the target by adding the category specified by Modifier's value.
+        /// Usable on Category fields.
+        /// </summary>
         [XmlEnum("add")]
         Add,
 
+        /// <summary>
+        /// Modifies the target by removing the category specified by Modifier's value.
+        /// Usable on Category fields.
+        /// </summary>
         [XmlEnum("remove")]
         Remove,
 
+        /// <summary>
+        /// Modifies the target by making the category specified by Modifier's value primary.
+        /// Usable on Category fields.
+        /// </summary>
         [XmlEnum("set-primary")]
         SetPrimary,
 
+        /// <summary>
+        /// Modifies the target by making the category specified by Modifier's value non-primary.
+        /// Usable on Category fields.
+        /// </summary>
         [XmlEnum("unset-primary")]
         UnsetPrimary
     }

--- a/src/WarHub.ArmouryModel.Source/PublicationCore.cs
+++ b/src/WarHub.ArmouryModel.Source/PublicationCore.cs
@@ -11,5 +11,17 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlAttribute("name")]
         public string? Name { get; }
+
+        [XmlAttribute("shortName")]
+        public string? ShortName { get; }
+
+        [XmlAttribute("publisher")]
+        public string? Publisher { get; }
+
+        [XmlAttribute("publicationDate")]
+        public string? PublicationDate { get; }
+
+        [XmlAttribute("publisherUrl")]
+        public string? PublisherUrl { get; }
     }
 }

--- a/src/WarHub.ArmouryModel.Source/QueryBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/QueryBaseCore.cs
@@ -3,7 +3,7 @@
 namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
-    public abstract partial class SelectorBaseCore : CommentableCore
+    public abstract partial class QueryBaseCore : CommentableCore
     {
         /// <summary>
         /// Defines what is actually being counted in the query.

--- a/src/WarHub.ArmouryModel.Source/QueryFilteredBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/QueryFilteredBaseCore.cs
@@ -1,0 +1,14 @@
+﻿using System.Xml.Serialization;
+
+namespace WarHub.ArmouryModel.Source
+{
+    [WhamNodeCore]
+    public abstract partial class QueryFilteredBaseCore : QueryBaseCore
+    {
+        /// <summary>
+        /// Changes the query to filter by this value.
+        /// </summary>
+        [XmlAttribute("childId")]
+        public string? ChildId { get; }
+    }
+}

--- a/src/WarHub.ArmouryModel.Source/RepeatCore.cs
+++ b/src/WarHub.ArmouryModel.Source/RepeatCore.cs
@@ -6,20 +6,14 @@ namespace WarHub.ArmouryModel.Source
     /// The repeat causes a Modifier to be applied multiple times, as calculated from
     /// the following:
     /// <see cref="RepeatCount"/> * [satisfaction count], where [satisfaction count] =
-    /// ([query result] / <see cref="SelectorBaseCore.Value"/>)
+    /// ([query result] / <see cref="QueryBaseCore.Value"/>)
     /// The [satisfaction count] is rounded down unless <see cref="RoundUp"/> is <see langword="true" />
     /// in which case it's rounded up.
     /// </summary>
     [WhamNodeCore]
     [XmlType("repeat")]
-    public sealed partial class RepeatCore : SelectorBaseCore
+    public sealed partial class RepeatCore : QueryFilteredBaseCore
     {
-        /// <summary>
-        /// Changes the query to filter by this value.
-        /// </summary>
-        [XmlAttribute("childId")]
-        public string? ChildId { get; }
-
         /// <summary>
         /// Number of times the Modifier owner of this repeat should be applied
         /// per one satisfaction in [satisfaction count] - see type summary.
@@ -28,7 +22,7 @@ namespace WarHub.ArmouryModel.Source
         public int RepeatCount { get; }
 
         /// <summary>
-        /// If <see langword="true" />, the result of dividing query result by <see cref="SelectorBaseCore.Value"/>
+        /// If <see langword="true" />, the result of dividing query result by <see cref="QueryBaseCore.Value"/>
         /// is rounded up; otherwise it's rounded down.
         /// </summary>
         [XmlAttribute("roundUp")]

--- a/src/WarHub.ArmouryModel.Source/RosterCore.cs
+++ b/src/WarHub.ArmouryModel.Source/RosterCore.cs
@@ -34,5 +34,11 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlArray("forces")]
         public ImmutableArray<ForceCore> Forces { get; }
+
+        [XmlElement("customNotes")]
+        public string? CustomNotes { get; }
+
+        [XmlArray("tags")]
+        public ImmutableArray<RosterTagCore> Tags { get; }
     }
 }

--- a/src/WarHub.ArmouryModel.Source/RosterElementBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/RosterElementBaseCore.cs
@@ -18,6 +18,12 @@ namespace WarHub.ArmouryModel.Source
         [XmlAttribute("entryGroupId")]
         public string? EntryGroupId { get; }
 
+        [XmlAttribute("customName")]
+        public string? CustomName { get; }
+
+        [XmlElement("customNotes")]
+        public string? CustomNotes { get; }
+
         [XmlAttribute("publicationId")]
         public string? PublicationId { get; }
 

--- a/src/WarHub.ArmouryModel.Source/RosterTagCore.cs
+++ b/src/WarHub.ArmouryModel.Source/RosterTagCore.cs
@@ -3,8 +3,8 @@
 namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
-    [XmlType("characteristicType")]
-    public sealed partial class CharacteristicTypeCore : CommentableCore
+    [XmlType("tag")]
+    public sealed partial class RosterTagCore
     {
         [XmlAttribute("id")]
         public string? Id { get; }

--- a/src/WarHub.ArmouryModel.Source/SelectionCore.cs
+++ b/src/WarHub.ArmouryModel.Source/SelectionCore.cs
@@ -5,16 +5,13 @@ namespace WarHub.ArmouryModel.Source
 {
     [WhamNodeCore]
     [XmlType("selection")]
-    public sealed partial class SelectionCore : RosterElementBaseCore
+    public sealed partial class SelectionCore : SelectionParentBaseCore
     {
         [XmlAttribute("number")]
         public int Number { get; }
 
         [XmlAttribute("type")]
         public SelectionEntryKind Type { get; }
-
-        [XmlArray("selections")]
-        public ImmutableArray<SelectionCore> Selections { get; }
 
         [XmlArray("costs")]
         public ImmutableArray<CostCore> Costs { get; }

--- a/src/WarHub.ArmouryModel.Source/SelectionParentBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/SelectionParentBaseCore.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Immutable;
+using System.Xml.Serialization;
+
+namespace WarHub.ArmouryModel.Source
+{
+    [WhamNodeCore]
+    public abstract partial class SelectionParentBaseCore : RosterElementBaseCore
+    {
+        [XmlArray("selections")]
+        public ImmutableArray<SelectionCore> Selections { get; }
+    }
+}

--- a/src/WarHub.ArmouryModel.Workspaces.BattleScribe/XmlFileExtensions.cs
+++ b/src/WarHub.ArmouryModel.Workspaces.BattleScribe/XmlFileExtensions.cs
@@ -235,7 +235,7 @@ namespace WarHub.ArmouryModel.Workspaces.BattleScribe
             if (archive.Entries.Count != 1)
             {
                 throw new InvalidOperationException(
-                    $"File is not a correct BattleScribe ZIP archive," +
+                    "File is not a correct BattleScribe ZIP archive," +
                     $" contains {archive.Entries.Count} entries, expected 1.");
             }
             using var entryStream = archive.Entries[0].Open();

--- a/src/dataformat/xml/schema/latest/Catalogue.xsd
+++ b/src/dataformat/xml/schema/latest/Catalogue.xsd
@@ -26,6 +26,10 @@
       <xs:extension base="tns:Commentable">
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="shortName" type="xs:string" />
+        <xs:attribute name="publisher" type="xs:string" />
+        <xs:attribute name="publicationDate" type="xs:string" />
+        <xs:attribute name="publisherUrl" type="xs:string" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -43,8 +47,12 @@
 
   <!--characteristic type-->
   <xs:complexType name="CharacteristicType">
-    <xs:attribute name="id" type="tns:idtype" use="required" />
-    <xs:attribute name="name" type="xs:string" use="required" />
+    <xs:complexContent>
+      <xs:extension base="tns:Commentable">
+        <xs:attribute name="id" type="tns:idtype" use="required" />
+        <xs:attribute name="name" type="xs:string" use="required" />
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="CharacteristicTypeList">
@@ -79,6 +87,7 @@
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="defaultCostLimit" type="xs:decimal" default="-1" />
+        <xs:attribute name="hidden" type="xs:boolean" default="false" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -409,8 +418,8 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <!--selector base-->
-  <xs:complexType name="SelectorBase">
+  <!--query base-->
+  <xs:complexType name="QueryBase">
     <xs:complexContent>
       <xs:extension base="tns:Commentable">
         <xs:attribute name="field" type="xs:string" />
@@ -423,11 +432,20 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  
+  <!--query filtered base-->
+  <xs:complexType name="QueryFilteredBase">
+    <xs:complexContent>
+      <xs:extension base="tns:QueryBase">
+        <xs:attribute name="childId" type="tns:idtype" use="required" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
 
   <!--constraint-->
   <xs:complexType name="Constraint">
     <xs:complexContent>
-      <xs:extension base="tns:SelectorBase">
+      <xs:extension base="tns:QueryBase">
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="type" type="tns:ConstraintKind" use="required" />
       </xs:extension>
@@ -447,8 +465,8 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <!--modifier-->
-  <xs:complexType name="Modifier">
+  <!--modifier base-->
+  <xs:complexType name="ModifierBase">
     <xs:complexContent>
       <xs:extension base="tns:Commentable">
         <xs:sequence>
@@ -456,6 +474,14 @@
           <xs:element name="conditions" type="tns:ConditionList" minOccurs="0" />
           <xs:element name="conditionGroups" type="tns:ConditionGroupList" minOccurs="0" />
         </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!--modifier-->
+  <xs:complexType name="Modifier">
+    <xs:complexContent>
+      <xs:extension base="tns:ModifierBase">
         <xs:attribute name="type" type="tns:ModifierKind" use="required" />
         <xs:attribute name="field" type="xs:string" use="required" />
         <xs:attribute name="value" type="xs:string" use="required" />
@@ -485,12 +511,10 @@
   <!--modifier group-->
   <xs:complexType name="ModifierGroup">
     <xs:complexContent>
-      <xs:extension base="tns:Commentable">
+      <xs:extension base="tns:ModifierBase">
         <xs:sequence>
-          <xs:element name="repeats" type="tns:RepeatList" minOccurs="0" />
-          <xs:element name="conditions" type="tns:ConditionList" minOccurs="0" />
-          <xs:element name="conditionGroups" type="tns:ConditionGroupList" minOccurs="0" />
           <xs:element name="modifiers" type="tns:ModifierList" minOccurs="0" />
+          <xs:element name="modifierGroups" type="tns:ModifierGroupList" minOccurs="0" />
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -505,8 +529,7 @@
   <!--repeat-->
   <xs:complexType name="Repeat">
     <xs:complexContent>
-      <xs:extension base="tns:SelectorBase">
-        <xs:attribute name="childId" type="tns:idtype" use="required" />
+      <xs:extension base="tns:QueryFilteredBase">
         <xs:attribute name="repeats" type="xs:positiveInteger" use="required" />
         <xs:attribute name="roundUp" type="xs:boolean" default="false" />
       </xs:extension>
@@ -522,8 +545,7 @@
   <!--condition-->
   <xs:complexType name="Condition">
     <xs:complexContent>
-      <xs:extension base="tns:SelectorBase">
-        <xs:attribute name="childId" type="tns:idtype" use="required" />
+      <xs:extension base="tns:QueryFilteredBase">
         <xs:attribute name="type" type="tns:ConditionKind" use="required" />
       </xs:extension>
     </xs:complexContent>
@@ -577,6 +599,7 @@
   <!--roster element base-->
   <xs:complexType name="RosterElementBase">
     <xs:sequence>
+      <xs:element name="customNotes" type="xs:string" minOccurs="0" />
       <xs:element name="rules" type="tns:RuleList" minOccurs="0" />
       <xs:element name="profiles" type="tns:ProfileList" minOccurs="0" />
     </xs:sequence>
@@ -584,15 +607,26 @@
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="entryId" type="tns:idtype" use="required" />
     <xs:attribute name="entryGroupId" type="tns:idtype" />
+    <xs:attribute name="customName" type="xs:string" />
     <xs:attributeGroup ref="tns:PublicationRefAttGroup" />
+  </xs:complexType>
+  
+  <!--selection parent base-->
+  <xs:complexType name="SelectionParentBase">
+    <xs:complexContent>
+      <xs:extension base="tns:RosterElementBase">
+        <xs:sequence>
+          <xs:element name="selections" type="tns:SelectionList" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <!--force-->
   <xs:complexType name="Force">
     <xs:complexContent>
-      <xs:extension base="tns:RosterElementBase">
+      <xs:extension base="tns:SelectionParentBase">
         <xs:sequence>
-          <xs:element name="selections" type="tns:SelectionList" minOccurs="0" />
           <xs:element name="publications" type="tns:PublicationList" minOccurs="0" />
           <xs:element name="categories" type="tns:CategoryList" minOccurs="0" />
           <xs:element name="forces" type="tns:ForceList" minOccurs="0" />
@@ -628,9 +662,8 @@
   <!--selection-->
   <xs:complexType name="Selection">
     <xs:complexContent>
-      <xs:extension base="tns:RosterElementBase">
+      <xs:extension base="tns:SelectionParentBase">
         <xs:sequence>
-          <xs:element name="selections" type="tns:SelectionList" minOccurs="0" />
           <xs:element name="costs" type="tns:CostList" minOccurs="0" />
           <xs:element name="categories" type="tns:CategoryList" minOccurs="0" />
         </xs:sequence>
@@ -643,6 +676,18 @@
   <xs:complexType name="SelectionList">
     <xs:sequence>
       <xs:element name="selection" type="tns:Selection" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!--roster tag-->
+  <xs:complexType name="RosterTag">
+    <xs:attribute name="id" type="tns:idtype" use="required" />
+    <xs:attribute name="name" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="RosterTagList">
+    <xs:sequence>
+      <xs:element name="tags" type="tns:RosterTag" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 
@@ -684,6 +729,8 @@
       <xs:element name="costs" type="tns:CostList" minOccurs="0" />
       <xs:element name="costLimits" type="tns:CostLimitList" minOccurs="0" />
       <xs:element name="forces" type="tns:ForceList" minOccurs="0" />
+      <xs:element name="customNotes" type="xs:string" minOccurs="0" />
+      <xs:element name="tags" type="tns:RosterTagList" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="id" type="tns:idtype" use="required" />
     <xs:attribute name="name" type="xs:string" use="required" />

--- a/src/dataformat/xml/schema/v2_03/Catalogue.xsd
+++ b/src/dataformat/xml/schema/v2_03/Catalogue.xsd
@@ -26,6 +26,10 @@
       <xs:extension base="tns:Commentable">
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="shortName" type="xs:string" />
+        <xs:attribute name="publisher" type="xs:string" />
+        <xs:attribute name="publicationDate" type="xs:string" />
+        <xs:attribute name="publisherUrl" type="xs:string" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -43,8 +47,12 @@
 
   <!--characteristic type-->
   <xs:complexType name="CharacteristicType">
-    <xs:attribute name="id" type="tns:idtype" use="required" />
-    <xs:attribute name="name" type="xs:string" use="required" />
+    <xs:complexContent>
+      <xs:extension base="tns:Commentable">
+        <xs:attribute name="id" type="tns:idtype" use="required" />
+        <xs:attribute name="name" type="xs:string" use="required" />
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:complexType name="CharacteristicTypeList">
@@ -79,6 +87,7 @@
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="defaultCostLimit" type="xs:decimal" default="-1" />
+        <xs:attribute name="hidden" type="xs:boolean" default="false" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -409,8 +418,8 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <!--selector base-->
-  <xs:complexType name="SelectorBase">
+  <!--query base-->
+  <xs:complexType name="QueryBase">
     <xs:complexContent>
       <xs:extension base="tns:Commentable">
         <xs:attribute name="field" type="xs:string" />
@@ -423,11 +432,20 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
+  
+  <!--query filtered base-->
+  <xs:complexType name="QueryFilteredBase">
+    <xs:complexContent>
+      <xs:extension base="tns:QueryBase">
+        <xs:attribute name="childId" type="tns:idtype" use="required" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
 
   <!--constraint-->
   <xs:complexType name="Constraint">
     <xs:complexContent>
-      <xs:extension base="tns:SelectorBase">
+      <xs:extension base="tns:QueryBase">
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="type" type="tns:ConstraintKind" use="required" />
       </xs:extension>
@@ -447,8 +465,8 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <!--modifier-->
-  <xs:complexType name="Modifier">
+  <!--modifier base-->
+  <xs:complexType name="ModifierBase">
     <xs:complexContent>
       <xs:extension base="tns:Commentable">
         <xs:sequence>
@@ -456,6 +474,14 @@
           <xs:element name="conditions" type="tns:ConditionList" minOccurs="0" />
           <xs:element name="conditionGroups" type="tns:ConditionGroupList" minOccurs="0" />
         </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!--modifier-->
+  <xs:complexType name="Modifier">
+    <xs:complexContent>
+      <xs:extension base="tns:ModifierBase">
         <xs:attribute name="type" type="tns:ModifierKind" use="required" />
         <xs:attribute name="field" type="xs:string" use="required" />
         <xs:attribute name="value" type="xs:string" use="required" />
@@ -485,12 +511,10 @@
   <!--modifier group-->
   <xs:complexType name="ModifierGroup">
     <xs:complexContent>
-      <xs:extension base="tns:Commentable">
+      <xs:extension base="tns:ModifierBase">
         <xs:sequence>
-          <xs:element name="repeats" type="tns:RepeatList" minOccurs="0" />
-          <xs:element name="conditions" type="tns:ConditionList" minOccurs="0" />
-          <xs:element name="conditionGroups" type="tns:ConditionGroupList" minOccurs="0" />
           <xs:element name="modifiers" type="tns:ModifierList" minOccurs="0" />
+          <xs:element name="modifierGroups" type="tns:ModifierGroupList" minOccurs="0" />
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
@@ -505,8 +529,7 @@
   <!--repeat-->
   <xs:complexType name="Repeat">
     <xs:complexContent>
-      <xs:extension base="tns:SelectorBase">
-        <xs:attribute name="childId" type="tns:idtype" use="required" />
+      <xs:extension base="tns:QueryFilteredBase">
         <xs:attribute name="repeats" type="xs:positiveInteger" use="required" />
         <xs:attribute name="roundUp" type="xs:boolean" default="false" />
       </xs:extension>
@@ -522,8 +545,7 @@
   <!--condition-->
   <xs:complexType name="Condition">
     <xs:complexContent>
-      <xs:extension base="tns:SelectorBase">
-        <xs:attribute name="childId" type="tns:idtype" use="required" />
+      <xs:extension base="tns:QueryFilteredBase">
         <xs:attribute name="type" type="tns:ConditionKind" use="required" />
       </xs:extension>
     </xs:complexContent>
@@ -577,6 +599,7 @@
   <!--roster element base-->
   <xs:complexType name="RosterElementBase">
     <xs:sequence>
+      <xs:element name="customNotes" type="xs:string" minOccurs="0" />
       <xs:element name="rules" type="tns:RuleList" minOccurs="0" />
       <xs:element name="profiles" type="tns:ProfileList" minOccurs="0" />
     </xs:sequence>
@@ -584,15 +607,26 @@
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="entryId" type="tns:idtype" use="required" />
     <xs:attribute name="entryGroupId" type="tns:idtype" />
+    <xs:attribute name="customName" type="xs:string" />
     <xs:attributeGroup ref="tns:PublicationRefAttGroup" />
+  </xs:complexType>
+  
+  <!--selection parent base-->
+  <xs:complexType name="SelectionParentBase">
+    <xs:complexContent>
+      <xs:extension base="tns:RosterElementBase">
+        <xs:sequence>
+          <xs:element name="selections" type="tns:SelectionList" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <!--force-->
   <xs:complexType name="Force">
     <xs:complexContent>
-      <xs:extension base="tns:RosterElementBase">
+      <xs:extension base="tns:SelectionParentBase">
         <xs:sequence>
-          <xs:element name="selections" type="tns:SelectionList" minOccurs="0" />
           <xs:element name="publications" type="tns:PublicationList" minOccurs="0" />
           <xs:element name="categories" type="tns:CategoryList" minOccurs="0" />
           <xs:element name="forces" type="tns:ForceList" minOccurs="0" />
@@ -628,9 +662,8 @@
   <!--selection-->
   <xs:complexType name="Selection">
     <xs:complexContent>
-      <xs:extension base="tns:RosterElementBase">
+      <xs:extension base="tns:SelectionParentBase">
         <xs:sequence>
-          <xs:element name="selections" type="tns:SelectionList" minOccurs="0" />
           <xs:element name="costs" type="tns:CostList" minOccurs="0" />
           <xs:element name="categories" type="tns:CategoryList" minOccurs="0" />
         </xs:sequence>
@@ -643,6 +676,18 @@
   <xs:complexType name="SelectionList">
     <xs:sequence>
       <xs:element name="selection" type="tns:Selection" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!--roster tag-->
+  <xs:complexType name="RosterTag">
+    <xs:attribute name="id" type="tns:idtype" use="required" />
+    <xs:attribute name="name" type="xs:string" use="required" />
+  </xs:complexType>
+
+  <xs:complexType name="RosterTagList">
+    <xs:sequence>
+      <xs:element name="tags" type="tns:RosterTag" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>
 
@@ -684,6 +729,8 @@
       <xs:element name="costs" type="tns:CostList" minOccurs="0" />
       <xs:element name="costLimits" type="tns:CostLimitList" minOccurs="0" />
       <xs:element name="forces" type="tns:ForceList" minOccurs="0" />
+      <xs:element name="customNotes" type="xs:string" minOccurs="0" />
+      <xs:element name="tags" type="tns:RosterTagList" minOccurs="0" />
     </xs:sequence>
     <xs:attribute name="id" type="tns:idtype" use="required" />
     <xs:attribute name="name" type="xs:string" use="required" />

--- a/tests/WarHub.ArmouryModel.Source.BattleScribe.Tests/XmlTestDatafiles/Grim and Dark Future/v2_03/Grim and Dark Future.gst.xml
+++ b/tests/WarHub.ArmouryModel.Source.BattleScribe.Tests/XmlTestDatafiles/Grim and Dark Future/v2_03/Grim and Dark Future.gst.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <gameSystem id="e1ebd931-a209-3ce4-87b4-d9918d25530b" name="Grim and Dark Future" revision="64" battleScribeVersion="2.03" authorName="Test Author" authorContact="@handle" authorUrl="http://example.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <costTypes>
-    <costType id="points" name="pts" defaultCostLimit="0.0"/>
+    <costType id="points" name="pts" defaultCostLimit="0.0" hidden="false"/>
   </costTypes>
   <profileTypes>
     <profileType id="2d6001b0-980e-46d2-bcc2-a9fc60109afd" name="Unit">

--- a/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_03Tests.cs
+++ b/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/XmlSchema2_03Tests.cs
@@ -3,7 +3,6 @@ using System.Xml;
 using System.Xml.Serialization;
 using FluentAssertions;
 using WarHub.ArmouryModel.Source.BattleScribe;
-using WarHub.ArmouryModel.Source.XmlFormat;
 using Xunit;
 using static WarHub.ArmouryModel.Source.NodeFactory;
 
@@ -90,7 +89,9 @@ spanning multiple lines</readme>
                 .AddInfoLinks(
                     InfoLink(Rule()))
                 .AddProfileTypes(
-                    ProfileType())
+                    ProfileType()
+                    .AddCharacteristicTypes(
+                        CharacteristicType()))
                 .AddPublications(
                     Publication())
                 .AddRules(

--- a/tests/WarHub.ArmouryModel.Workspaces.Gitree.Tests/SourceNodeToGitreeConverterTests.cs
+++ b/tests/WarHub.ArmouryModel.Workspaces.Gitree.Tests/SourceNodeToGitreeConverterTests.cs
@@ -22,7 +22,7 @@ namespace WarHub.ArmouryModel.Workspaces.Gitree.Tests
         [Fact]
         public void FolderKindDroppingRewriter_ClearsCorrectList()
         {
-            var characteristicType = NodeFactory.CharacteristicType("id", "name");
+            var characteristicType = NodeFactory.CharacteristicType("name");
             var profile = NodeFactory.ProfileType("name").AddCharacteristicTypes(characteristicType);
             var rewriter = new SourceNodeToGitreeConverter.SeparatableChildrenRemover();
             var result = (DatablobNode)NodeFactory.Datablob(


### PR DESCRIPTION
There were new fields added in BSv2.03:

- hidden on CostType: https://github.com/BSData/schemas/issues/7
- Publication publisher details: https://github.com/BSData/schemas/issues/6

There are some back-fixes:
- added `ModifierGroup.ModifierGroups` (missing from previous update that added ModifierGroup)
- added `CharacteristicType.Comment` (missing from when comment was introduced)
- added `Roster.CustomNotes` (BattleScribe Supporter feature)
- added `Roster.Tags` (BattleScribe Supporter feature?)
- added `RosterElementBase.CustomName` (BattleScribe Supporter feature)
- added `RosterElementBase.CustomNotes` (BattleScribe Supporter feature)

There are also some changes to inheritance:
- SelectorBase renamed to QueryBase
- introduced QueryFilteredBase, a base for Condition and Repeat
- introduced ModifierBase, a base for Modifier and ModifierGroup
- introduced SelectionParentBase, a base for Force and Selection