### PR TITLE
Simplify getting `SourceText` in source generator

### DIFF
--- a/src/WarHub.ArmouryModel.Source.CodeGeneration/RoslynWhamNodeGenerator.cs
+++ b/src/WarHub.ArmouryModel.Source.CodeGeneration/RoslynWhamNodeGenerator.cs
@@ -46,7 +46,7 @@ namespace WarHub.ArmouryModel.Source.CodeGeneration
                 SymbolEqualityComparer.Default.Equals(descriptorBuilder.WhamNodeCoreAttributeSymbol, data.AttributeClass);
 
             void AddSource(string hintName, CompilationUnitSyntax compilationUnit) =>
-                context.AddSource(hintName, SyntaxTree(compilationUnit, context.ParseOptions, encoding: Encoding.UTF8).GetText());
+                context.AddSource(hintName, compilationUnit.GetText(Encoding.UTF8));
         }
 
         private static CompilationUnitSyntax CreateSource(CoreDescriptor descriptor)


### PR DESCRIPTION
There's no reason to create a `SyntaxTree` first. The text will be reparsed anyway by Roslyn. This change avoid doing additional work in the source generator for no benefit. The recommended way to add a source from a `CompilationUnitSyntax` is to use `compilationUnit.GetText(Encoding.UTF8)`. See https://github.com/dotnet/roslyn/issues/61506