### PR TITLE
Update ModifierKind.cs to include prepend

### DIFF
--- a/src/WarHub.ArmouryModel.Source/ModifierKind.cs
+++ b/src/WarHub.ArmouryModel.Source/ModifierKind.cs
@@ -33,6 +33,13 @@ namespace WarHub.ArmouryModel.Source
         Append,
 
         /// <summary>
+        /// Modifies the target by prepending its value with Modifier's value.
+        /// Usable on String fields.
+        /// </summary>
+        [XmlEnum("prepend")]
+        Prepend,
+
+        /// <summary>
         /// Modifies the target by adding the category specified by Modifier's value.
         /// Usable on Category fields.
         /// </summary>


### PR DESCRIPTION
NewRecruit's data editor now allows for a Prepend modifier

The enum seemed to be missing it and thus was failing validation on perfectly good data files