### PR TITLE
ci: extract publish workflow with NuGet trusted publishing

### DIFF
--- a/.github/workflows/deploy-command.yml
+++ b/.github/workflows/deploy-command.yml
@@ -6,99 +6,18 @@ name: Deploy
 on:
   repository_dispatch:
     types: [deploy-command]
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref to deploy (branch, tag, or SHA)'
-        required: false
-        default: 'main'
-      env:
-        description: 'Target environment (github, nuget, all)'
-        required: false
-        default: 'github'
-        type: choice
-        options:
-          - github
-          - nuget
-          - all
-      tag:
-        description: 'Tag the ref with version from nbgv'
-        required: false
-        default: false
-        type: boolean
+
 jobs:
-  pack:
-    runs-on: ubuntu-latest
-    env:
-      DOTNET_NOLOGO: 1
-      PUSH_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.client_payload.slash_command.args.unnamed.arg1 == 'tag' }}
-    steps:
-      - name: Add deployment run link to command comment
-        if: github.event_name == 'repository_dispatch'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: "[Deployment run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # all history
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.client_payload.slash_command.args.named.ref }}
-      - uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.0.x'
-      - run: dotnet --info
-      - run: dotnet tool restore
-      - run: dotnet nbgv get-version
-      - run: dotnet restore -v m
-      - run: dotnet build --no-restore
-      - run: dotnet test --no-build
-      - run: dotnet pack
-      - name: Add and push version tag
-        if: env.PUSH_TAG == 'true'
-        id: tagpush
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          $env:PublicRelease = $true
-          $v = "v$(dotnet nbgv get-version -v SemVer2)"
-          git tag $v
-          git push origin $v
-          Write-Host "::set-output name=tag::$v"
-      - name: Add tag info to command comment
-        if: env.PUSH_TAG == 'true' && github.event_name == 'repository_dispatch'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          body: "Pushed tag `${{ steps.tagpush.outputs.tag }}`"
-      - name: Upload nugets to workflow artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: nugets
-          path: artifacts/package/release
-  push:
-    runs-on: ubuntu-latest
-    needs: pack
-    env:
-      DOTNET_NOLOGO: 1
-      PUSH_TO: ${{ github.event_name == 'workflow_dispatch' && inputs.env || github.event.client_payload.slash_command.args.named.env }}
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: nugets
-
-      - name: Push to nuget.org
-        if: env.PUSH_TO == 'all' || env.PUSH_TO == 'nuget'
-        shell: pwsh
-        run: dotnet nuget push '*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_APIKEY }} --skip-duplicate
-
-      - name: Push to GitHub Packages
-        if: env.PUSH_TO == 'all' || env.PUSH_TO == 'github' || env.PUSH_TO == ''
-        shell: pwsh
-        run: dotnet nuget push '*.nupkg' -s https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json -k ${{ github.token }} --skip-duplicate
-
-      - name: Add reaction to command comment
-        if: github.event_name == 'repository_dispatch'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reactions: hooray
+  publish:
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    with:
+      ref: ${{ github.event.client_payload.slash_command.args.named.ref || '' }}
+      push-to: ${{ github.event.client_payload.slash_command.args.named.env || 'github' }}
+      tag: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'tag' }}
+      comment-id: ${{ github.event.client_payload.github.payload.comment.id }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,132 @@
+name: Publish
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to build and publish (branch, tag, or SHA)'
+        type: string
+        default: ''
+      push-to:
+        description: 'Package registries to push to: github, nuget, or all'
+        type: string
+        default: 'github'
+      tag:
+        description: 'Tag the ref with nbgv version before publishing'
+        type: boolean
+        default: false
+      comment-id:
+        description: 'GitHub comment ID for status updates (optional)'
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build and publish (branch, tag, or SHA)'
+        required: false
+        default: ''
+      push-to:
+        description: 'Package registries to push to'
+        required: false
+        default: 'github'
+        type: choice
+        options:
+          - github
+          - nuget
+          - all
+      tag:
+        description: 'Tag the ref with nbgv version before publishing'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: 1
+    steps:
+      - name: Link run to comment
+        if: inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          body: "[Publish run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # all history
+          ref: ${{ inputs.ref || '' }}
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet --info
+      - run: dotnet tool restore
+      - run: dotnet nbgv get-version
+      - run: dotnet restore -v m
+      - run: dotnet build --no-restore
+      - run: dotnet test --no-build
+      - run: dotnet pack
+      - name: Add and push version tag
+        if: inputs.tag
+        id: tagpush
+        shell: pwsh
+        run: |
+          $env:PublicRelease = $true
+          $v = "v$(dotnet nbgv get-version -v SemVer2)"
+          git tag $v
+          git push origin $v
+          "tag=$v" >> $env:GITHUB_OUTPUT
+      - name: Update comment with tag
+        if: inputs.tag && inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          body: "Pushed tag `${{ steps.tagpush.outputs.tag }}`"
+      - name: Upload nugets
+        uses: actions/upload-artifact@v7
+        with:
+          name: nugets
+          path: artifacts/package/release
+
+  push:
+    runs-on: ubuntu-latest
+    needs: pack
+    environment: package-release
+    env:
+      DOTNET_NOLOGO: 1
+      PUSH_TO: ${{ inputs.push-to }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: nugets
+
+      - name: NuGet login (trusted publishing)
+        if: env.PUSH_TO == 'all' || env.PUSH_TO == 'nuget'
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: warhub
+
+      - name: Push to nuget.org
+        if: env.PUSH_TO == 'all' || env.PUSH_TO == 'nuget'
+        shell: pwsh
+        run: dotnet nuget push '*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
+
+      - name: Push to GitHub Packages
+        if: env.PUSH_TO == 'all' || env.PUSH_TO == 'github' || env.PUSH_TO == ''
+        shell: pwsh
+        run: dotnet nuget push '*.nupkg' -s https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json -k ${{ github.token }} --skip-duplicate
+
+      - name: React to comment
+        if: inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          reactions: hooray

--- a/.github/workflows/tag-command.yml
+++ b/.github/workflows/tag-command.yml
@@ -40,7 +40,7 @@ jobs:
           $v = "v$(dotnet nbgv get-version -v SemVer2)"
           git tag $v
           git push origin $v
-          Write-Host "::set-output name=tag::$v"
+          "tag=$v" >> $env:GITHUB_OUTPUT
       - name: Add tag info and reaction to command comment
         if: github.event_name == 'repository_dispatch'
         uses: peter-evans/create-or-update-comment@v5

--- a/README.md
+++ b/README.md
@@ -69,6 +69,66 @@ This project uses `Nerdbank.GitVersioning` package that automatically generates 
 for assemblies and packages from git tree. It won't work if the git clone is *shallow* or otherwise
 incomplete.
 
+## Release Process
+
+### Preparing a release
+
+1. Create a PR that sets `version.json` to the stable version (e.g. `"0.14"`) and updates
+   `CHANGELOG.md` with the release date. Merge the PR.
+2. Tag the merged commit: `git tag vX.Y.Z && git push origin vX.Y.Z`
+3. After tagging, create a PR to bump `version.json` to the next alpha version
+   (e.g. `"0.15.0-alpha.{height}"`) and add an `[Unreleased]` section to `CHANGELOG.md`.
+
+### Publishing packages
+
+Packages are published via the **Publish** workflow (`.github/workflows/publish.yml`).
+
+**Via GitHub CLI or Actions UI** (recommended):
+
+```bash
+# Publish to GitHub Packages only
+gh workflow run publish.yml -f ref=vX.Y.Z -f push-to=github
+
+# Publish to nuget.org only
+gh workflow run publish.yml -f ref=vX.Y.Z -f push-to=nuget
+
+# Publish to both registries
+gh workflow run publish.yml -f ref=vX.Y.Z -f push-to=all
+```
+
+**Via ChatOps** (requires `SLASH_COMMAND_DISPATCH_TOKEN` secret):
+
+Comment on any issue or PR:
+```
+/deploy ref=vX.Y.Z env=all
+```
+
+### NuGet trusted publishing
+
+NuGet.org publishing uses [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+(OIDC) instead of long-lived API keys. The trusted publishing policy is configured on nuget.org for:
+
+| Field              | Value              |
+|--------------------|--------------------|
+| Package Owner      | `warhub`           |
+| Repository Owner   | `WarHub`           |
+| Repository         | `wham`             |
+| Workflow           | `publish.yml`      |
+| Environment        | `package-release`  |
+
+The `push` job in `publish.yml` uses `environment: package-release` which provides
+environment protection rules (e.g. required reviewers) as a gate before publishing.
+
+### Tagging
+
+Tags can also be created via the **Tag** workflow:
+
+```bash
+gh workflow run tag-command.yml -f ref=main
+```
+
+Or via ChatOps: `/tag ref=main`
+
 ## Credits
 
 The library is MIT licensed (license in repo root).


### PR DESCRIPTION
## Summary

Extracts build-test-pack-push pipeline into a standalone publish.yml reusable workflow.

### New: publish.yml

Callable via workflow_dispatch and workflow_call:

    gh workflow run publish.yml -f ref=v0.14.0 -f push-to=all

Key features:
- push job uses environment: package-release for protection rules
- NuGet.org uses trusted publishing (OIDC via NuGet/login@v1) - no API key secrets
- Optional comment-id input for chatops status updates

### Simplified: deploy-command.yml

Thin chatops wrapper calling publish.yml as reusable workflow.

### Other changes
- Fix deprecated set-output in tag-command.yml
- Add Release Process docs to README.md
