### PR TITLE
ci: use NUGET_USER_NAME env secret for trusted publishing

### DIFF
--- a/.github/workflows/deploy-command.yml
+++ b/.github/workflows/deploy-command.yml
@@ -21,3 +21,4 @@ jobs:
       push-to: ${{ github.event.client_payload.slash_command.args.named.env || 'github' }}
       tag: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'tag' }}
       comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
         uses: NuGet/login@v1
         id: nuget-login
         with:
-          user: warhub
+          user: ${{ secrets.NUGET_USER_NAME }}
 
       - name: Push to nuget.org
         if: env.PUSH_TO == 'all' || env.PUSH_TO == 'nuget'

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ NuGet.org publishing uses [Trusted Publishing](https://learn.microsoft.com/en-us
 The `push` job in `publish.yml` uses `environment: package-release` which provides
 environment protection rules (e.g. required reviewers) as a gate before publishing.
 
+The NuGet profile name is configured via the `NUGET_USER_NAME` environment secret
+on the `package-release` environment.
+
 ### Tagging
 
 Tags can also be created via the **Tag** workflow:


### PR DESCRIPTION
Use secrets.NUGET_USER_NAME from package-release environment instead of hardcoded nuget.org profile name. Add secrets: inherit to deploy-command caller.