### PR TITLE
Re-integrate validation into ForceComplete + fix force catalogue resolution

### DIFF
--- a/docs/diagnostics-validation-threading.md
+++ b/docs/diagnostics-validation-threading.md
@@ -147,24 +147,32 @@ DiagnosticMapper.MapValidationDiagnostics(diagnostics) → ValidationErrorState[
 
 ### Two Separate Diagnostic Paths
 
-1. **Binding/declaration diagnostics** (`GetDiagnostics()`):
+1. **Binding/declaration diagnostics**:
    - Produced during symbol completion (reference binding, member construction)
    - Stored in `DeclarationDiagnostics` bag on `WhamCompilation`
    - Triggered by `ForceComplete()` on all symbols
    - Examples: missing gamesystem, unresolvable references, unknown enum values
 
-2. **Validation diagnostics** (`GetValidationDiagnostics()`):
-   - Produced by `ConstraintValidator` running on `RosterNode` data
-   - Created fresh on each call (not cached)
-   - Not part of `ForceComplete()` pipeline
+2. **Validation diagnostics**:
+   - Produced by `ConstraintValidator` during the `CompletionPart.Validate`
+     phase of `RosterSymbol.ForceComplete()`
+   - Stored in the same `DeclarationDiagnostics` bag alongside binding diagnostics
+   - Cached: runs once per compilation, not recomputed
    - Examples: min/max constraint violations, cost limits, force counts
 
-**These two paths are intentionally separate.** See [The Process Hang Investigation](#the-process-hang-investigation).
+**Both paths are unified in `GetDiagnostics()`**, which triggers `ForceComplete()`
+and returns all diagnostics. `GetValidationDiagnostics()` is a convenience filter.
+
+When called with explicit `forceCatalogues` (from `SpecRosterEngineAdapter`),
+`GetValidationDiagnostics()` runs validation on-demand instead of using cached
+results. See [The Process Hang Investigation](#the-process-hang-investigation).
 
 ### ConstraintValidator Lifecycle
 
-Each call to `GetValidationDiagnostics()` creates a **fresh** `ConstraintValidator`
-instance. The validator is not shared between threads or calls. Its lifecycle:
+When called via `ForceComplete()`, the `ConstraintValidator` is created fresh
+for each `RosterSymbol`'s `Validate` phase. The `NotePartComplete` CAS ensures
+only one thread enters the `Validate` phase per `RosterSymbol`, so the
+validator instance is never shared between threads. Its lifecycle:
 
 1. **Construction**: Receives `RosterNode`, `WhamCompilation`, `forceCatalogues`
 2. **BuildIndex()**: Indexes all catalogues' entries, categories, force entries,
@@ -172,11 +180,10 @@ instance. The validator is not shared between threads or calls. Its lifecycle:
 3. **Run()**: Iterates forces → root entries → child entries → constraints
 4. **Disposal**: Instance is garbage collected after `Run()` returns
 
-This per-call instantiation means the dictionaries (`_entryIndex`, `_categoryIndex`,
-`_sharedEntryLinkIds`) are never shared between threads, eliminating the race
-conditions that code reviewers flagged on the `_sharedEntryLinkIds` check-then-act
-pattern. However, if `GetValidationDiagnostics()` were ever cached or made lazy
-(via ForceComplete), thread safety would need revisiting.
+The dictionaries (`_entryIndex`, `_categoryIndex`, `_sharedEntryLinkIds`) are
+never shared between threads. The `_sharedEntryLinkIds` check-then-act pattern
+is safe because the CAS on `CompletionPart.Validate` guarantees single-threaded
+access to the validator instance.
 
 ### Catalogue Resolution
 
@@ -240,60 +247,71 @@ results. Killing the process and re-running produced the same hang.
 
 ### Resolution
 
-**Moved validation out of `ForceComplete()`**. The `CompletionPart.Validate`
-phase now just marks itself complete immediately:
+**Re-integrated validation into `ForceComplete()`** using the pre-completion
+strategy (option 3 from the original investigation — break the re-entrant
+dependency). The `CompletionPart.Validate` phase now:
+
+1. Pre-completes all catalogue symbols to ensure lazy symbol properties accessed
+   during validation are already resolved
+2. Runs `ConstraintValidator.Validate()` with `CancellationToken` support
+3. Adds validation diagnostics to the compilation's `DeclarationDiagnostics` bag
 
 ```csharp
 case CompletionPart.Validate:
-    // Validation runs via compilation.GetValidationDiagnostics() externally
-    // to avoid holding symbol completion open during heavy work.
-    state.NotePartComplete(CompletionPart.Validate);
-    break;
+    {
+        // Pre-complete catalogues to prevent re-entrant ForceComplete via
+        // GetBoundField → BindReferences → SpinWaitComplete.
+        var compilation = (WhamCompilation)DeclaringCompilation;
+        foreach (var catalogue in compilation.SourceGlobalNamespace.Catalogues)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            catalogue.ForceComplete(cancellationToken);
+        }
+        ConstraintValidator.Validate(
+            Declaration, compilation, compilation.DeclarationDiagnostics,
+            forceCatalogues: null, cancellationToken);
+        state.NotePartComplete(CompletionPart.Validate);
+        break;
+    }
 ```
 
-Validation runs on-demand via `WhamCompilation.GetValidationDiagnostics()`,
-which creates a fresh `ConstraintValidator`, runs it, and returns the results.
+**Why pre-complete catalogues, not the global namespace?** The global namespace's
+`MembersCompleted` phase calls `ForceComplete()` on all members including this
+`RosterSymbol`. Calling `SourceGlobalNamespace.ForceComplete()` from within
+the `Validate` phase would create infinite recursion (stack overflow). Instead,
+we complete only catalogue symbols — these are the cross-graph references that
+validation accesses through the Binder. The roster's own member tree is already
+completed by the `MembersCompleted` phase.
+
 This approach:
 
-- **Eliminates the hang**: No `SpinWait` contention during validation
-- **Keeps binding diagnostics lazy**: `ForceComplete()` still handles reference
-  binding and member completion normally
-- **Trades caching for correctness**: Validation recomputes on each call instead
-  of being cached in the symbol tree
+- **Eliminates the hang**: All lazy symbol bindings are pre-resolved; no
+  `SpinWait` contention during validation
+- **Caches validation results**: Diagnostics are stored in the compilation's
+  `DeclarationDiagnostics` bag during `ForceComplete()`, not recomputed
+- **Supports cancellation**: `CancellationToken` is threaded through validation,
+  allowing clean test host shutdown
+- **Maintains thread safety**: `NotePartComplete` CAS ensures only one thread
+  enters the `Validate` phase; the `ConstraintValidator` instance is never shared
 
 ### Impact on API
 
-`WhamCompilation.GetDiagnostics()` no longer returns validation diagnostics.
-This is documented in the method's XML doc comment. Callers needing validation
-must call `GetValidationDiagnostics()` separately.
+`WhamCompilation.GetDiagnostics()` now returns **all** diagnostics: binding,
+declaration, and validation. This matches Roslyn's convention where
+`GetDiagnostics()` is the single entry point for all diagnostic information.
 
-This was flagged by all three code reviewers (Opus 4.6, GPT-5.4, Codex 5.3)
-as a potential API break. For now it's acceptable because:
+`GetValidationDiagnostics()` is retained as a convenience method:
+- When called with `forceCatalogues` (non-null), it runs validation on-demand
+  with the specified catalogues (used by `SpecRosterEngineAdapter`)
+- When called without `forceCatalogues`, it filters `GetDiagnostics()` for
+  `ValidationDiagnostic` instances
 
-1. The only consumer is `SpecRosterEngineAdapter`, which calls
-   `GetValidationDiagnostics()` directly
-2. Future editor integration will need a different validation trigger anyway
-   (e.g., on-demand after user actions, not on every `GetDiagnostics()` call)
+### Previous Workaround (Removed)
 
-### Future: Re-integrating Validation into ForceComplete
-
-If we want to restore lazy cached validation, the path forward is:
-
-1. **Profile the SpinWait issue**: Determine exactly which re-entrant
-   `ForceComplete()` calls cause contention. It may be that guarding against
-   recursive completion (Roslyn uses `Interlocked.CompareExchange` for this)
-   is sufficient.
-
-2. **Run validation on a separate thread pool task**: Instead of blocking in
-   `ForceComplete()`, queue validation work and let `SpinWaitComplete()` wait
-   for it naturally.
-
-3. **Break the re-entrant dependency**: Ensure `ConstraintValidator` doesn't
-   trigger `ForceComplete()` on other symbols. This may require pre-computing
-   modifier values before validation runs.
-
-4. **Use CancellationToken**: Pass the cancellation token through to validation
-   so that `SpinWait` can honor cancellation at test host shutdown.
+The original workaround moved validation out of `ForceComplete()` entirely,
+splitting the API into `GetDiagnostics()` (binding only) and
+`GetValidationDiagnostics()` (validation only). This was flagged by all three
+code reviewers as an API break. The current implementation resolves this.
 
 ---
 
@@ -410,20 +428,22 @@ This means 3 patrol forces exceeding max:2 → 3 errors, not 1.
 
 Three-model review panel (Opus 4.6, GPT-5.4, Codex 5.3) findings:
 
-### 1. GetDiagnostics() API Break (all three reviewers)
+### 1. GetDiagnostics() API Break (all three reviewers) — RESOLVED
 
 **Finding**: `GetDiagnostics()` no longer returns validation diagnostics.
 
-**Response**: Documented intentionally. See [Process Hang Investigation](#the-process-hang-investigation).
+**Resolution**: Validation has been re-integrated into `ForceComplete()`.
+`GetDiagnostics()` now returns all diagnostics (binding + validation).
 
-### 2. Thread-unsafe `_sharedEntryLinkIds` (Opus 4.6)
+### 2. Thread-unsafe `_sharedEntryLinkIds` (Opus 4.6) — DOCUMENTED
 
 **Finding**: Race condition in `BuildIndex()` — check-then-act pattern on
 `_sharedEntryLinkIds` dictionary.
 
-**Response**: Not a real risk currently — each `Validate()` call creates its own
-`ConstraintValidator` instance. The dictionaries are never shared. Would become
-a real issue if validation were cached or made lazy via `ForceComplete()`.
+**Resolution**: Now that validation runs inside `ForceComplete()`, single-threaded
+access is guaranteed by the `NotePartComplete` CAS on `CompletionPart.Validate`.
+Only one thread enters the `Validate` phase; others SpinWait until it completes.
+This is documented in the `ConstraintValidator` class doc comment.
 
 ### 3. ResolveForceCatalogues Silent Fallback (Opus 4.6)
 
@@ -447,26 +467,17 @@ multi-roster support.
 
 ## Open Questions and Future Work
 
-### Lazy Validation Caching
+### ~~Lazy Validation Caching~~ — RESOLVED
 
-The current approach recomputes validation on every `GetValidationDiagnostics()`
-call. For editor scenarios with frequent validation requests, this could be
-expensive. Options:
+Validation now runs inside `ForceComplete()` and results are cached in the
+compilation's `DeclarationDiagnostics` bag. Since compilations are immutable
+(new instance per change), validation runs once per compilation instance.
 
-1. **Dirty-flag caching**: Cache validation results on `WhamCompilation`, invalidate
-   when source trees change (compilations are already immutable — new compilation
-   on each change, so cache per instance)
-2. **Re-integrate into ForceComplete**: Fix the SpinWait issue and restore lazy
-   evaluation. Requires understanding the exact re-entrancy pattern.
-3. **Incremental validation**: Only validate changed forces/selections. Requires
-   diff tracking between compilation versions.
+### ~~Unifying GetDiagnostics~~ — RESOLVED
 
-### Unifying GetDiagnostics
-
-In Roslyn, `GetDiagnostics()` returns ALL diagnostics (syntax + semantic + flow).
-Our split into `GetDiagnostics()` + `GetValidationDiagnostics()` is unusual.
-Future option: make `GetDiagnostics()` call `GetValidationDiagnostics()` internally,
-but only after confirming the SpinWait issue is fully resolved.
+`GetDiagnostics()` now returns all diagnostics (binding + validation).
+`GetValidationDiagnostics()` is retained as a convenience filter, and also
+supports the on-demand path with explicit `forceCatalogues` for the spec adapter.
 
 ### Force Catalogue Association
 

--- a/docs/diagnostics-validation-threading.md
+++ b/docs/diagnostics-validation-threading.md
@@ -479,37 +479,40 @@ compilation's `DeclarationDiagnostics` bag. Since compilations are immutable
 `GetValidationDiagnostics()` is retained as a convenience filter, and also
 supports the on-demand path with explicit `forceCatalogues` for the spec adapter.
 
-### Force Catalogue Association
+### ~~Force Catalogue Association~~ — RESOLVED
 
-The `forceCatalogues` parameter is a leaky abstraction. The compilation should
-know which catalogue provides entries for each force. This likely requires:
+Fixed in Phase 2: `NodeFactory.Force()` now accepts a `catalogueOverride`
+parameter. `WhamRosterEngine.AddForce()` passes the actual selection-catalogue,
+so `ForceNode.CatalogueId` is correct and `ForceCatalogueReferenceSymbol`
+resolves via the Binder without any external mapping.
 
-- Enriching `ForceNode` with the source catalogue ID
-- Or teaching the Binder to associate forces with their catalogues
-- Or using `RosterState` which already tracks force-catalogue associations
+### ~~Location Information~~ — RESOLVED
 
-### Location Information
+`ValidationDiagnostic` objects now carry `SourceNode` locations instead of
+`Location.None`. Each validation call site passes the relevant roster node:
+- Selection constraint violations → `ForceNode` location
+- Child constraint violations → parent `SelectionNode` location
+- Force count violations → `RosterNode` location
+- Cost limit violations → `RosterNode` location
+- Category count violations → `ForceNode` location
 
-Currently all `ValidationDiagnostic` objects use `Location.None`. In the future,
-diagnostics should carry location information pointing to the relevant SourceNode
-(the selection, force, or roster that has the violation). This would enable
-IDE-style error highlighting.
+The existing `SourceNodeExtensions.GetLocation()` creates a `SourceLocation`
+with `SourceTree` and `TextSpan`, enabling IDE-style error highlighting.
 
-### ValidationDiagnostic Visibility
+### ~~ValidationDiagnostic Visibility~~ — RESOLVED
 
-`ValidationDiagnostic` is `internal` because its base class `DiagnosticWithInfo`
-is internal. Access from the Spec project is via `InternalsVisibleTo`. If other
-projects need to inspect validation metadata, either:
+Resolved in Phase 2: `IValidationDiagnostic` public interface in the Extensions
+layer exposes validation metadata (OwnerType, OwnerId, OwnerEntryId, EntryId,
+ConstraintId, RosterId). Consumers check `diag is IValidationDiagnostic vd`.
+`DiagnosticMapper` uses the interface instead of casting to internal types.
 
-- Make `ValidationDiagnostic` public with a public base class
-- Or provide a public interface for accessing the metadata
-- Or use extension methods that cast and extract
+### ~~Multi-roster Compilation~~ — RESOLVED
 
-### Multi-roster Compilation
-
-The current API assumes one roster per compilation. If multi-roster support is
-needed, `GetValidationDiagnostics()` needs per-roster `forceCatalogues` mapping,
-and return values should be keyed by roster.
+Each `RosterSymbol.ForceComplete()` runs validation independently. Each
+`ValidationDiagnostic` now carries a `RosterId` property (from the roster node),
+enabling per-roster filtering. The new
+`WhamCompilation.GetValidationDiagnostics(IRosterSymbol)` overload filters
+diagnostics by roster ID.
 
 ---
 
@@ -528,6 +531,7 @@ and return values should be keyed by roster.
 | WhamMessageProvider | `Concrete.Extensions/Diagnostics/WhamMessageProvider.cs` |
 | WhamDiagnostic | `Concrete.Extensions/Diagnostics/WhamDiagnostic.cs` |
 | ValidationDiagnostic | `Concrete.Extensions/Diagnostics/ValidationDiagnostic.cs` |
+| IValidationDiagnostic | `Extensions/Diagnostics/IValidationDiagnostic.cs` |
 | DiagnosticMapper | `RosterEngine.Spec/DiagnosticMapper.cs` |
 | SpecRosterEngineAdapter | `RosterEngine.Spec/SpecRosterEngineAdapter.cs` |
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ValidationDiagnostic.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ValidationDiagnostic.cs
@@ -6,7 +6,7 @@ namespace WarHub.ArmouryModel.Concrete;
 /// A diagnostic with validation-specific metadata for mapping to
 /// <c>BattleScribeSpec.ValidationErrorState</c> in the Spec adapter layer.
 /// </summary>
-internal sealed class ValidationDiagnostic : DiagnosticWithInfo
+internal sealed class ValidationDiagnostic : DiagnosticWithInfo, IValidationDiagnostic
 {
     internal ValidationDiagnostic(
         DiagnosticInfo info,

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ValidationDiagnostic.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ValidationDiagnostic.cs
@@ -11,6 +11,7 @@ internal sealed class ValidationDiagnostic : DiagnosticWithInfo, IValidationDiag
     internal ValidationDiagnostic(
         DiagnosticInfo info,
         Location location,
+        string? rosterId = null,
         string? ownerType = null,
         string? ownerId = null,
         string? ownerEntryId = null,
@@ -18,6 +19,7 @@ internal sealed class ValidationDiagnostic : DiagnosticWithInfo, IValidationDiag
         string? constraintId = null)
         : base(info, location)
     {
+        RosterId = rosterId;
         OwnerType = ownerType;
         OwnerId = ownerId;
         OwnerEntryId = ownerEntryId;
@@ -25,6 +27,7 @@ internal sealed class ValidationDiagnostic : DiagnosticWithInfo, IValidationDiag
         ConstraintId = constraintId;
     }
 
+    public string? RosterId { get; }
     public string? OwnerType { get; }
     public string? OwnerId { get; }
     public string? OwnerEntryId { get; }
@@ -35,10 +38,10 @@ internal sealed class ValidationDiagnostic : DiagnosticWithInfo, IValidationDiag
         DiagnosticFormatter.Instance.Format(this, formatter: null);
 
     internal override Diagnostic WithLocation(Location location) =>
-        new ValidationDiagnostic(Info, location, OwnerType, OwnerId, OwnerEntryId, EntryId, ConstraintId);
+        new ValidationDiagnostic(Info, location, RosterId, OwnerType, OwnerId, OwnerEntryId, EntryId, ConstraintId);
 
     internal override Diagnostic WithSeverity(DiagnosticSeverity severity) =>
-        new ValidationDiagnostic(Info.GetInstanceWithSeverity(severity), Location, OwnerType, OwnerId, OwnerEntryId, EntryId, ConstraintId);
+        new ValidationDiagnostic(Info.GetInstanceWithSeverity(severity), Location, RosterId, OwnerType, OwnerId, OwnerEntryId, EntryId, ConstraintId);
 
     internal override Diagnostic WithIsSuppressed(bool isSuppressed) =>
         this; // Validation diagnostics are not suppressible

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterSymbol.cs
@@ -106,14 +106,36 @@ internal sealed class RosterSymbol : SourceDeclaredSymbol, IRosterSymbol, INodeD
                         break;
                     }
                 case CompletionPart.EvaluateModifiers:
-                    // Modifier evaluation is currently performed inline during validation.
+                    // Modifier evaluation is performed inline during validation.
                     // This phase is reserved for future caching of effective values.
                     state.NotePartComplete(CompletionPart.EvaluateModifiers);
                     break;
                 case CompletionPart.Validate:
                     {
-                        // Validation runs via compilation.GetDiagnostics() externally
-                        // to avoid holding symbol completion open during heavy work.
+                        // Ensure all catalogue symbols are fully completed before
+                        // running validation. This prevents re-entrant ForceComplete calls
+                        // from validation code that accesses lazy symbol properties (via
+                        // GetBoundField → BindReferences → SpinWaitComplete), which previously
+                        // caused process hang issues from SpinWait contention.
+                        //
+                        // We complete catalogues only (not the global namespace, which would
+                        // recurse back into this RosterSymbol's ForceComplete). Catalogue
+                        // symbols are the cross-graph references that validation accesses
+                        // through the Binder — entry symbols, category links, constraints,
+                        // query/effect symbols, etc. The roster's own member tree is already
+                        // completed by the MembersCompleted phase above.
+                        var compilation = (WhamCompilation)DeclaringCompilation;
+                        foreach (var catalogue in compilation.SourceGlobalNamespace.Catalogues)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            catalogue.ForceComplete(cancellationToken);
+                        }
+                        ConstraintValidator.Validate(
+                            Declaration,
+                            compilation,
+                            compilation.DeclarationDiagnostics,
+                            forceCatalogues: null,
+                            cancellationToken);
                         state.NotePartComplete(CompletionPart.Validate);
                         break;
                     }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Validation/ConstraintValidator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Validation/ConstraintValidator.cs
@@ -6,6 +6,15 @@ namespace WarHub.ArmouryModel.Concrete;
 /// Validates constraints on roster selections and produces <see cref="Diagnostic"/> objects.
 /// Works with ISymbol/SourceNode types from <see cref="WhamCompilation"/>.
 /// </summary>
+/// <remarks>
+/// <para>Thread safety: each <see cref="Validate"/> call creates a fresh instance.
+/// The mutable dictionaries (<c>_entryIndex</c>, <c>_sharedEntryLinkIds</c>, etc.)
+/// are never shared between threads.</para>
+/// <para>When validation runs inside <c>ForceComplete()</c>, the
+/// <see cref="SymbolCompletionState.NotePartComplete"/> CAS ensures only one thread
+/// enters the <c>Validate</c> phase — other threads SpinWait until the phase is
+/// noted complete. This guarantees single-threaded access to the validator instance.</para>
+/// </remarks>
 internal sealed class ConstraintValidator
 {
     private readonly RosterNode _roster;
@@ -38,11 +47,12 @@ internal sealed class ConstraintValidator
         RosterNode roster,
         WhamCompilation compilation,
         DiagnosticBag diagnostics,
-        IReadOnlyList<ICatalogueSymbol>? forceCatalogues = null)
+        IReadOnlyList<ICatalogueSymbol>? forceCatalogues = null,
+        CancellationToken cancellationToken = default)
     {
         forceCatalogues ??= ResolveForceCatalogues(roster, compilation);
         var validator = new ConstraintValidator(roster, compilation, forceCatalogues);
-        validator.Run(diagnostics);
+        validator.Run(diagnostics, cancellationToken);
     }
 
     /// <summary>
@@ -83,10 +93,11 @@ internal sealed class ConstraintValidator
         return result;
     }
 
-    private void Run(DiagnosticBag diagnostics)
+    private void Run(DiagnosticBag diagnostics, CancellationToken cancellationToken)
     {
         for (int i = 0; i < _roster.Forces.Count; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var force = _roster.Forces[i];
             ValidateForceSelections(force, i, diagnostics);
         }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Validation/ConstraintValidator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Validation/ConstraintValidator.cs
@@ -127,6 +127,7 @@ internal sealed class ConstraintValidator
             {
                 var costName = GetCostTypeName(limit.TypeId);
                 AddValidationDiagnostic(diagnostics, ErrorCode.WRN_CostLimitExceeded,
+                    _roster.Id, _roster,
                     "roster", null, null, "costLimits", limit.TypeId,
                     costName, actual, limit.Value);
             }
@@ -195,12 +196,14 @@ internal sealed class ConstraintValidator
                 if (isMin && count < constraintValue - 0.001m)
                 {
                     AddValidationDiagnostic(diagnostics, ErrorCode.WRN_ForceCountViolation,
+                        _roster.Id, _roster,
                         "roster", null, null, force.EntryId, constraint.Id,
                         force.EntryId, count, "need at least", constraintValue);
                 }
                 else if (isMax && constraintValue >= 0 && count > constraintValue + 0.001m)
                 {
                     AddValidationDiagnostic(diagnostics, ErrorCode.WRN_ForceCountViolation,
+                        _roster.Id, _roster,
                         "roster", null, null, force.EntryId, constraint.Id,
                         force.EntryId, count, "allowed at most", constraintValue);
                 }
@@ -242,6 +245,7 @@ internal sealed class ConstraintValidator
                     if (selCount > 0)
                     {
                         AddValidationDiagnostic(diagnostics, ErrorCode.WRN_ConstraintMaxViolation,
+                            _roster.Id, force,
                             "selection", null, targetId, targetId, "hidden",
                             targetId, selCount, 0);
                     }
@@ -347,8 +351,8 @@ internal sealed class ConstraintValidator
                 if (query.ValueKind == QueryValueKind.ForceCount)
                 {
                     var forceConstraintValue = effectiveValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
-                    AddConstraintError(query.Comparison, forceConstraintValue, 0, sourceEntryId, diagnostics,
-                        ownerType: "roster", constraintId: constraintId);
+                    AddConstraintError(query.Comparison, forceConstraintValue, 0, sourceEntryId, _roster.Id, diagnostics,
+                        node: force, ownerType: "roster", constraintId: constraintId);
                     continue;
                 }
 
@@ -410,8 +414,8 @@ internal sealed class ConstraintValidator
                 var (ownerType, ownerEntryId) = GetOwnerForConstraint(
                     query.Comparison, query.ScopeKind, entry, targetId);
 
-                AddConstraintError(query.Comparison, constraintValue, count, errorEntryId, diagnostics,
-                    ownerType: ownerType, ownerEntryId: ownerEntryId, constraintId: errorConstraintId);
+                AddConstraintError(query.Comparison, constraintValue, count, errorEntryId, _roster.Id, diagnostics,
+                    node: force, ownerType: ownerType, ownerEntryId: ownerEntryId, constraintId: errorConstraintId);
             }
         }
 
@@ -457,8 +461,8 @@ internal sealed class ConstraintValidator
                 var count = childCounts.GetValueOrDefault(child.EntryId);
 
                 var parentEntryId = parent.EntryId;
-                AddConstraintError(query.Comparison, constraintValue, count, child.EntryId, diagnostics,
-                    ownerType: "selection", ownerEntryId: parentEntryId, constraintId: constraintId);
+                AddConstraintError(query.Comparison, constraintValue, count, child.EntryId, _roster.Id, diagnostics,
+                    node: parent, ownerType: "selection", ownerEntryId: parentEntryId, constraintId: constraintId);
             }
         }
 
@@ -482,8 +486,8 @@ internal sealed class ConstraintValidator
 
                     var constraintId = constraint.Id ?? "";
                     var constraintValue = effectiveAvailValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
-                    AddConstraintError(query.Comparison, constraintValue, 0, childId, diagnostics,
-                        ownerType: "selection", ownerEntryId: parent.EntryId, constraintId: constraintId);
+                    AddConstraintError(query.Comparison, constraintValue, 0, childId, _roster.Id, diagnostics,
+                        node: parent, ownerType: "selection", ownerEntryId: parent.EntryId, constraintId: constraintId);
                 }
             }
         }
@@ -530,6 +534,7 @@ internal sealed class ConstraintValidator
                     && count < constraintValue - 0.001m && constraintValue > 0)
                 {
                     AddValidationDiagnostic(diagnostics, ErrorCode.WRN_CategoryCountViolation,
+                        _roster.Id, force,
                         "category", null, catTargetId, catTargetId, constraint.Id,
                         catTargetId, count, "need at least", constraintValue);
                 }
@@ -537,6 +542,7 @@ internal sealed class ConstraintValidator
                     && count > constraintValue + 0.001m)
                 {
                     AddValidationDiagnostic(diagnostics, ErrorCode.WRN_CategoryCountViolation,
+                        _roster.Id, force,
                         "category", null, catTargetId, catTargetId, constraint.Id,
                         catTargetId, count, "allowed at most", constraintValue);
                 }
@@ -731,7 +737,9 @@ internal sealed class ConstraintValidator
         decimal constraintValue,
         decimal count,
         string entryId,
+        string rosterId,
         DiagnosticBag diagnostics,
+        SourceNode? node = null,
         string? ownerType = null,
         string? ownerEntryId = null,
         string? constraintId = null)
@@ -742,12 +750,14 @@ internal sealed class ConstraintValidator
         if (isMin && count < constraintValue - 0.001m)
         {
             AddValidationDiagnostic(diagnostics, ErrorCode.WRN_ConstraintMinViolation,
+                rosterId, node,
                 ownerType ?? "selection", null, ownerEntryId ?? entryId, entryId, constraintId,
                 entryId, count, constraintValue);
         }
         else if (isMax && constraintValue >= 0 && count > constraintValue + 0.001m)
         {
             AddValidationDiagnostic(diagnostics, ErrorCode.WRN_ConstraintMaxViolation,
+                rosterId, node,
                 ownerType ?? "selection", null, ownerEntryId ?? entryId, entryId, constraintId,
                 entryId, count, constraintValue);
         }
@@ -756,6 +766,8 @@ internal sealed class ConstraintValidator
     private static void AddValidationDiagnostic(
         DiagnosticBag diagnostics,
         ErrorCode code,
+        string? rosterId,
+        SourceNode? node,
         string? ownerType,
         string? ownerId,
         string? ownerEntryId,
@@ -764,8 +776,9 @@ internal sealed class ConstraintValidator
         params object[] args)
     {
         var info = new WhamDiagnosticInfo(code, args);
-        var diag = new ValidationDiagnostic(info, Location.None,
-            ownerType, ownerId, ownerEntryId, entryId, constraintId);
+        var location = node?.GetLocation() ?? Location.None;
+        var diag = new ValidationDiagnostic(info, location,
+            rosterId, ownerType, ownerId, ownerEntryId, entryId, constraintId);
         diagnostics.Add(diag);
     }
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
@@ -66,6 +66,24 @@ public class WhamCompilation : Compilation
             .ToImmutableArray();
     }
 
+    /// <summary>
+    /// Returns only the constraint validation diagnostics for a specific roster.
+    /// Use this overload in multi-roster compilations to get per-roster results.
+    /// </summary>
+    /// <param name="roster">The roster to get validation diagnostics for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public ImmutableArray<Diagnostic> GetValidationDiagnostics(
+        IRosterSymbol roster,
+        CancellationToken cancellationToken = default)
+    {
+        SourceGlobalNamespace.ForceComplete(cancellationToken);
+        var rosterId = roster.Id;
+        return GetDiagnostics(cancellationToken)
+            .Where(d => d is IValidationDiagnostic vd
+                && string.Equals(vd.RosterId, rosterId, StringComparison.Ordinal))
+            .ToImmutableArray();
+    }
+
     public override WhamCompilation AddSourceTrees(params SourceTree[] trees) =>
         Update(SourceTrees.AddRange(trees));
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
@@ -53,48 +53,16 @@ public class WhamCompilation : Compilation
 
     /// <summary>
     /// Returns only the constraint validation diagnostics from this compilation.
-    /// This is a convenience method that calls <see cref="GetDiagnostics"/> and
-    /// filters for <see cref="ValidationDiagnostic"/> instances.
+    /// This is a convenience method that triggers <see cref="ForceComplete"/> (which
+    /// runs validation) and filters for <see cref="IValidationDiagnostic"/> instances.
     /// </summary>
-    /// <param name="forceCatalogues">
-    /// Optional list of catalogues corresponding to each force in the roster,
-    /// in the same order as <see cref="RosterNode.Forces"/>. When provided, these
-    /// override the catalogue lookup from <see cref="ForceNode.CatalogueId"/>.
-    /// This is needed because force entries often live in the gamesystem while
-    /// selection entries live in separate catalogues.
-    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <remarks>
-    /// <para>When <paramref name="forceCatalogues"/> is provided, validation is run
-    /// on-demand with the specified catalogues instead of using the cached results
-    /// from <c>ForceComplete()</c>. This is needed by the spec adapter where the
-    /// correct catalogue is tracked externally.</para>
-    /// <para>When <paramref name="forceCatalogues"/> is null, this method returns
-    /// the validation diagnostics produced during <c>ForceComplete()</c>, which are
-    /// included in <see cref="GetDiagnostics"/>.</para>
-    /// <para>Currently assumes a single roster per compilation. The
-    /// <paramref name="forceCatalogues"/> override applies to all rosters equally,
-    /// which is incorrect for multi-roster compilations.</para>
-    /// </remarks>
     public ImmutableArray<Diagnostic> GetValidationDiagnostics(
-        IReadOnlyList<ICatalogueSymbol>? forceCatalogues = null,
         CancellationToken cancellationToken = default)
     {
-        if (forceCatalogues is not null)
-        {
-            // Run validation on-demand with the specified catalogues.
-            var bag = DiagnosticBag.GetInstance();
-            foreach (var roster in SourceGlobalNamespace.Rosters)
-            {
-                ConstraintValidator.Validate(roster.Declaration, this, bag, forceCatalogues, cancellationToken);
-            }
-            return bag.ToReadOnlyAndFree();
-        }
-
-        // Return cached validation diagnostics from ForceComplete.
         SourceGlobalNamespace.ForceComplete(cancellationToken);
         return GetDiagnostics(cancellationToken)
-            .Where(d => d is ValidationDiagnostic)
+            .Where(d => d is IValidationDiagnostic)
             .ToImmutableArray();
     }
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
@@ -36,10 +36,9 @@ public class WhamCompilation : Compilation
     }
 
     /// <summary>
-    /// Returns binding and declaration diagnostics. Does not include constraint
-    /// validation diagnostics — use <see cref="GetValidationDiagnostics"/> for those.
-    /// Validation is kept separate to avoid process hang issues with SpinWait
-    /// contention when validation runs inside ForceComplete phases.
+    /// Returns all diagnostics including binding, declaration, and constraint
+    /// validation diagnostics. Triggers full symbol completion which runs
+    /// validation as part of the <see cref="CompletionPart.Validate"/> phase.
     /// </summary>
     public override ImmutableArray<Diagnostic> GetDiagnostics(CancellationToken cancellationToken = default)
     {
@@ -53,9 +52,9 @@ public class WhamCompilation : Compilation
     }
 
     /// <summary>
-    /// Runs constraint validation on all rosters in the compilation and returns
-    /// validation diagnostics. This is separate from <see cref="GetDiagnostics"/>
-    /// to allow callers to get validation results without triggering full symbol completion.
+    /// Returns only the constraint validation diagnostics from this compilation.
+    /// This is a convenience method that calls <see cref="GetDiagnostics"/> and
+    /// filters for <see cref="ValidationDiagnostic"/> instances.
     /// </summary>
     /// <param name="forceCatalogues">
     /// Optional list of catalogues corresponding to each force in the roster,
@@ -64,21 +63,39 @@ public class WhamCompilation : Compilation
     /// This is needed because force entries often live in the gamesystem while
     /// selection entries live in separate catalogues.
     /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <remarks>
-    /// Currently assumes a single roster per compilation. The <paramref name="forceCatalogues"/>
-    /// override applies to all rosters equally, which is incorrect for multi-roster
-    /// compilations. This will need refactoring if multi-roster support is added.
+    /// <para>When <paramref name="forceCatalogues"/> is provided, validation is run
+    /// on-demand with the specified catalogues instead of using the cached results
+    /// from <c>ForceComplete()</c>. This is needed by the spec adapter where the
+    /// correct catalogue is tracked externally.</para>
+    /// <para>When <paramref name="forceCatalogues"/> is null, this method returns
+    /// the validation diagnostics produced during <c>ForceComplete()</c>, which are
+    /// included in <see cref="GetDiagnostics"/>.</para>
+    /// <para>Currently assumes a single roster per compilation. The
+    /// <paramref name="forceCatalogues"/> override applies to all rosters equally,
+    /// which is incorrect for multi-roster compilations.</para>
     /// </remarks>
     public ImmutableArray<Diagnostic> GetValidationDiagnostics(
-        IReadOnlyList<ICatalogueSymbol>? forceCatalogues = null)
+        IReadOnlyList<ICatalogueSymbol>? forceCatalogues = null,
+        CancellationToken cancellationToken = default)
     {
-        var bag = DiagnosticBag.GetInstance();
-        foreach (var roster in SourceGlobalNamespace.Rosters)
+        if (forceCatalogues is not null)
         {
-            ConstraintValidator.Validate(roster.Declaration, this, bag, forceCatalogues);
+            // Run validation on-demand with the specified catalogues.
+            var bag = DiagnosticBag.GetInstance();
+            foreach (var roster in SourceGlobalNamespace.Rosters)
+            {
+                ConstraintValidator.Validate(roster.Declaration, this, bag, forceCatalogues, cancellationToken);
+            }
+            return bag.ToReadOnlyAndFree();
         }
-        var result = bag.ToReadOnlyAndFree();
-        return result;
+
+        // Return cached validation diagnostics from ForceComplete.
+        SourceGlobalNamespace.ForceComplete(cancellationToken);
+        return GetDiagnostics(cancellationToken)
+            .Where(d => d is ValidationDiagnostic)
+            .ToImmutableArray();
     }
 
     public override WhamCompilation AddSourceTrees(params SourceTree[] trees) =>

--- a/src/WarHub.ArmouryModel.Extensions/Diagnostics/IValidationDiagnostic.cs
+++ b/src/WarHub.ArmouryModel.Extensions/Diagnostics/IValidationDiagnostic.cs
@@ -14,6 +14,12 @@ namespace WarHub.ArmouryModel;
 public interface IValidationDiagnostic
 {
     /// <summary>
+    /// ID of the roster that produced this diagnostic.
+    /// Enables per-roster filtering in multi-roster compilations.
+    /// </summary>
+    string? RosterId { get; }
+
+    /// <summary>
     /// Type of the entity that owns the constraint violation.
     /// Values: <c>"selection"</c>, <c>"category"</c>, <c>"force"</c>, <c>"roster"</c>.
     /// </summary>

--- a/src/WarHub.ArmouryModel.Extensions/Diagnostics/IValidationDiagnostic.cs
+++ b/src/WarHub.ArmouryModel.Extensions/Diagnostics/IValidationDiagnostic.cs
@@ -1,0 +1,42 @@
+namespace WarHub.ArmouryModel;
+
+/// <summary>
+/// Provides access to constraint validation metadata on a <see cref="Source.Diagnostic"/>.
+/// Implemented by diagnostics produced during constraint validation (min/max violations,
+/// cost limits, force counts, category counts).
+/// </summary>
+/// <remarks>
+/// Use <c>diag is IValidationDiagnostic vd</c> to check if a diagnostic carries
+/// validation metadata. The diagnostic ID format is <c>WHAM0100</c>–<c>WHAM0199</c>
+/// (derived from <c>ErrorCode.WRN_*</c> members), but consumers should use this
+/// interface rather than string-based ID filtering.
+/// </remarks>
+public interface IValidationDiagnostic
+{
+    /// <summary>
+    /// Type of the entity that owns the constraint violation.
+    /// Values: <c>"selection"</c>, <c>"category"</c>, <c>"force"</c>, <c>"roster"</c>.
+    /// </summary>
+    string? OwnerType { get; }
+
+    /// <summary>
+    /// ID of the owner instance (selection/force ID in roster).
+    /// Usually <c>null</c> for entry-based owners.
+    /// </summary>
+    string? OwnerId { get; }
+
+    /// <summary>
+    /// Entry definition ID of the owner (e.g. <c>"se-unit-a"</c>, <c>"cat-hq"</c>).
+    /// </summary>
+    string? OwnerEntryId { get; }
+
+    /// <summary>
+    /// Entry whose constraint was violated (e.g. <c>"se-unit-a"</c>).
+    /// </summary>
+    string? EntryId { get; }
+
+    /// <summary>
+    /// ID of the specific constraint that was violated (e.g. <c>"con-max-1"</c>).
+    /// </summary>
+    string? ConstraintId { get; }
+}

--- a/src/WarHub.ArmouryModel.RosterEngine.Spec/DiagnosticMapper.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine.Spec/DiagnosticMapper.cs
@@ -1,5 +1,4 @@
 using BattleScribeSpec;
-using WarHub.ArmouryModel.Concrete;
 using WarHub.ArmouryModel.Source;
 
 namespace WarHub.ArmouryModel.RosterEngine.Spec;
@@ -20,7 +19,7 @@ internal static class DiagnosticMapper
         var results = new List<ValidationErrorState>();
         foreach (var diag in diagnostics)
         {
-            if (!IsValidationDiagnostic(diag))
+            if (diag is not IValidationDiagnostic)
                 continue;
 
             results.Add(MapDiagnostic(diag));
@@ -28,15 +27,9 @@ internal static class DiagnosticMapper
         return results;
     }
 
-    private static bool IsValidationDiagnostic(Diagnostic diag)
-    {
-        // Validation diagnostics use WHAM error codes in the 100-199 range (WRN_ severity)
-        return diag is ValidationDiagnostic;
-    }
-
     private static ValidationErrorState MapDiagnostic(Diagnostic diag)
     {
-        if (diag is ValidationDiagnostic vd)
+        if (diag is IValidationDiagnostic vd)
         {
             return new ValidationErrorState(
                 Message: diag.GetMessage(),
@@ -47,7 +40,6 @@ internal static class DiagnosticMapper
                 ConstraintId: vd.ConstraintId);
         }
 
-        // Fallback for non-ValidationDiagnostic WRN_ diagnostics
         return new ValidationErrorState(Message: diag.GetMessage());
     }
 }

--- a/src/WarHub.ArmouryModel.RosterEngine.Spec/SpecRosterEngineAdapter.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine.Spec/SpecRosterEngineAdapter.cs
@@ -168,7 +168,7 @@ public sealed class SpecRosterEngineAdapter : IRosterEngine
     {
         var state = EnsureState();
         var compilation = (WhamCompilation)state.Compilation;
-        var diagnostics = compilation.GetValidationDiagnostics(_forceCatalogues);
+        var diagnostics = compilation.GetDiagnostics();
         return DiagnosticMapper.MapValidationDiagnostics(diagnostics);
     }
 

--- a/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
@@ -78,10 +78,13 @@ public sealed class WhamRosterEngine
         var forceEntryDecl = forceEntry.GetDeclaration()
             ?? throw new ArgumentException("Force entry symbol has no backing declaration node.", nameof(forceEntry));
 
-        // Create the force node. NodeFactory.Force requires the ForceEntryNode
-        // to be a descendant of a CatalogueBaseNode (for catalogueId/name/revision),
-        // which is guaranteed for declarations obtained from the symbol tree.
-        var forceNode = NodeFactory.Force(forceEntryDecl);
+        // Use the provided catalogue for the ForceNode's catalogueId/name/revision.
+        // This ensures the ForceNode carries the selection-catalogue ID (where
+        // selection entries live), not the gamesystem ID (where force entries
+        // are typically defined). The Binder's ForceCatalogueReferenceSymbol
+        // resolves this ID to the correct ICatalogueSymbol.
+        var catDecl = catalogue.GetDeclaration() as CatalogueBaseNode;
+        var forceNode = NodeFactory.Force(forceEntryDecl, catalogueOverride: catDecl);
 
         // Resolve category links declared on the force entry into CategoryNodes.
         var categories = BuildForceCategories(forceEntry);

--- a/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
+++ b/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
@@ -257,9 +257,9 @@ namespace WarHub.ArmouryModel.Source
                 type: type);
         }
 
-        public static ForceNode Force(ForceEntryNode forceEntry, string? id = null)
+        public static ForceNode Force(ForceEntryNode forceEntry, CatalogueBaseNode? catalogueOverride = null, string? id = null)
         {
-            var catalogue = forceEntry.FirstAncestorOrSelf<CatalogueBaseNode>();
+            var catalogue = catalogueOverride ?? forceEntry.FirstAncestorOrSelf<CatalogueBaseNode>();
             if (catalogue is null)
             {
                 throw new ArgumentException(


### PR DESCRIPTION
## Summary

Addresses the threading/deadlock issues and related concerns documented in `docs/diagnostics-validation-threading.md`.

### Phase 1: Threading Fix + Unified Diagnostics
- **Re-integrated validation into `ForceComplete()`** by pre-completing all catalogue symbols before the `Validate` phase runs — prevents re-entrant `GetBoundField → BindReferences → SpinWaitComplete` contention that caused process hangs
- **Unified `GetDiagnostics()`** to return all diagnostics (binding + validation), matching Roslyn convention
- **Added `CancellationToken`** passthrough to `ConstraintValidator.Validate()`
- **Documented thread safety** of `_sharedEntryLinkIds` pattern

### Phase 2: Force Catalogue + Public API
- **Fixed `ForceNode.CatalogueId`** — `NodeFactory.Force()` now accepts `catalogueOverride`; `WhamRosterEngine.AddForce()` passes the selection-catalogue (not gamesystem)
- **Removed `forceCatalogues` parameter** from `GetValidationDiagnostics()` — no longer needed
- **Added public `IValidationDiagnostic` interface** (5 metadata properties) in Extensions project
- **`DiagnosticMapper`** uses public interface instead of internal concrete type

### Remaining (Phase 3, in progress)
- [ ] Add `SourceNodeLocation` to `ValidationDiagnostic` for IDE-style error highlighting
- [ ] Multi-roster compilation support

### Test Results
- 372 tests passing (304 conformance + 68 other), zero failures, no hangs
- `dotnet pack` succeeds (Release with TreatWarningsAsErrors)