### PR TITLE
SymbolKey: Cross-compilation symbol identity for all symbol types

### DIFF
--- a/src/WarHub.ArmouryModel.Concrete.Extensions/SymbolIndex.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/SymbolIndex.cs
@@ -1,0 +1,209 @@
+namespace WarHub.ArmouryModel.Concrete;
+
+/// <summary>
+/// Lazy per-compilation index for efficient <see cref="SymbolKey"/> resolution.
+/// Indexes all identifiable symbols by (Kind, ContainingModuleId, SymbolId) for O(1) lookup.
+/// </summary>
+internal sealed class SymbolIndex
+{
+    private readonly Dictionary<(SymbolKind Kind, string? ModuleId, string? SymbolId), List<ISymbol>> _index;
+
+    private SymbolIndex(Dictionary<(SymbolKind, string?, string?), List<ISymbol>> index)
+    {
+        _index = index;
+    }
+
+    internal static SymbolIndex Build(WhamCompilation compilation)
+    {
+        var index = new Dictionary<(SymbolKind, string?, string?), List<ISymbol>>();
+        var ns = compilation.GlobalNamespace;
+
+        // Index catalogue symbols.
+        foreach (var catalogue in ns.Catalogues)
+        {
+            IndexSymbol(index, catalogue);
+            IndexCatalogueContents(index, catalogue);
+        }
+
+        // Index roster symbols.
+        foreach (var roster in ns.Rosters)
+        {
+            IndexSymbol(index, roster);
+            IndexRosterContents(index, roster);
+        }
+
+        return new SymbolIndex(index);
+    }
+
+    internal SymbolKeyResolution Resolve(SymbolKey key)
+    {
+        var lookupKey = (key.Kind, key.ContainingModuleId, key.SymbolId);
+
+        if (!_index.TryGetValue(lookupKey, out var candidates) || candidates.Count == 0)
+        {
+            return SymbolKeyResolution.Missing();
+        }
+
+        if (candidates.Count == 1)
+        {
+            return SymbolKeyResolution.Resolved(candidates[0]);
+        }
+
+        // Multiple matches — try to disambiguate via ContainingEntryId.
+        if (key.ContainingEntryId is not null)
+        {
+            var filtered = candidates
+                .Where(s => GetContainingEntryId(s) == key.ContainingEntryId)
+                .ToList();
+            if (filtered.Count == 1)
+            {
+                return SymbolKeyResolution.Resolved(filtered[0]);
+            }
+            if (filtered.Count > 1)
+            {
+                return SymbolKeyResolution.Ambiguous([.. filtered]);
+            }
+        }
+
+        return SymbolKeyResolution.Ambiguous([.. candidates]);
+    }
+
+    private static string? GetContainingEntryId(ISymbol symbol)
+    {
+        for (var parent = symbol.ContainingSymbol; parent is not null; parent = parent.ContainingSymbol)
+        {
+            switch (parent.Kind)
+            {
+                case SymbolKind.Catalogue:
+                case SymbolKind.Roster:
+                case SymbolKind.Namespace:
+                    return null;
+                case SymbolKind.ContainerEntry:
+                case SymbolKind.Container:
+                    return parent.Id;
+            }
+        }
+        return null;
+    }
+
+    private static void IndexSymbol(
+        Dictionary<(SymbolKind, string?, string?), List<ISymbol>> index,
+        ISymbol symbol)
+    {
+        if (symbol.Id is null)
+            return;
+
+        var key = (symbol.Kind, symbol.ContainingModule?.Id, symbol.Id);
+        if (!index.TryGetValue(key, out var list))
+        {
+            list = [];
+            index[key] = list;
+        }
+        list.Add(symbol);
+    }
+
+    private static void IndexCatalogueContents(
+        Dictionary<(SymbolKind, string?, string?), List<ISymbol>> index,
+        ICatalogueSymbol catalogue)
+    {
+        // Resource definitions (cost types, profile types, characteristic types).
+        foreach (var resDef in catalogue.ResourceDefinitions)
+        {
+            IndexSymbol(index, resDef);
+        }
+
+        // Root resource entries (profiles, rules, info groups, publications).
+        foreach (var resEntry in catalogue.RootResourceEntries)
+        {
+            IndexSymbol(index, resEntry);
+        }
+
+        // Root container entries (selection entries, force entries, category entries, links).
+        foreach (var entry in catalogue.RootContainerEntries)
+        {
+            IndexContainerEntry(index, entry);
+        }
+
+        // Shared selection entry containers.
+        foreach (var shared in catalogue.SharedSelectionEntryContainers)
+        {
+            IndexContainerEntry(index, shared);
+        }
+    }
+
+    private static void IndexContainerEntry(
+        Dictionary<(SymbolKind, string?, string?), List<ISymbol>> index,
+        IContainerEntrySymbol entry)
+    {
+        IndexSymbol(index, entry);
+
+        // Index child entries recursively.
+        if (entry is ISelectionEntryContainerSymbol selectionContainer)
+        {
+            foreach (var child in selectionContainer.ChildSelectionEntries)
+            {
+                IndexContainerEntry(index, child);
+            }
+        }
+
+        // Index resources attached to this entry.
+        if (entry is IEntrySymbol entrySymbol)
+        {
+            foreach (var resource in entrySymbol.Resources)
+            {
+                IndexSymbol(index, resource);
+            }
+        }
+    }
+
+    private static void IndexRosterContents(
+        Dictionary<(SymbolKind, string?, string?), List<ISymbol>> index,
+        IRosterSymbol roster)
+    {
+        foreach (var force in roster.Forces)
+        {
+            IndexForce(index, force);
+        }
+
+        foreach (var cost in roster.Costs)
+        {
+            IndexSymbol(index, cost);
+        }
+    }
+
+    private static void IndexForce(
+        Dictionary<(SymbolKind, string?, string?), List<ISymbol>> index,
+        IForceSymbol force)
+    {
+        IndexSymbol(index, force);
+
+        foreach (var category in force.Categories)
+        {
+            IndexSymbol(index, category);
+        }
+
+        foreach (var selection in force.Selections)
+        {
+            IndexSelection(index, selection);
+        }
+
+        // Nested forces.
+        foreach (var childForce in force.Forces)
+        {
+            IndexForce(index, childForce);
+        }
+    }
+
+    private static void IndexSelection(
+        Dictionary<(SymbolKind, string?, string?), List<ISymbol>> index,
+        ISelectionSymbol selection)
+    {
+        IndexSymbol(index, selection);
+
+        // Nested selections.
+        foreach (var childSelection in selection.Selections)
+        {
+            IndexSelection(index, childSelection);
+        }
+    }
+}

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/WhamCompilation.cs
@@ -9,6 +9,7 @@ public class WhamCompilation : Compilation
     private DiagnosticBag? lazyDeclarationDiagnostics;
     private DiagnosticBag? lazyConstraintDiagnostics;
     private ICategoryEntrySymbol? lazyNoCategoryEntrySymbol;
+    private SymbolIndex? lazySymbolIndex;
 
     internal WhamCompilation(string? name, ImmutableArray<SourceTree> sourceTrees, CompilationOptions options)
         : base(name, sourceTrees, options)
@@ -81,6 +82,22 @@ public class WhamCompilation : Compilation
     {
         diagnostics.Add(ErrorCode.ERR_MissingGamesystem, Location.None);
         return new ErrorSymbols.ErrorGamesystemSymbol();
+    }
+
+    public override SymbolKeyResolution ResolveSymbolKey(SymbolKey key)
+    {
+        return GetSymbolIndex().Resolve(key);
+    }
+
+    private SymbolIndex GetSymbolIndex()
+    {
+        if (lazySymbolIndex is not null)
+        {
+            return lazySymbolIndex;
+        }
+        var index = SymbolIndex.Build(this);
+        Interlocked.CompareExchange(ref lazySymbolIndex, index, null);
+        return lazySymbolIndex;
     }
 
     internal Binder GetBinder(SourceNode node, ISymbol? containingSymbol)

--- a/src/WarHub.ArmouryModel.EditorServices/RosterOperations.cs
+++ b/src/WarHub.ArmouryModel.EditorServices/RosterOperations.cs
@@ -34,8 +34,8 @@ public static class RosterOperations
     public static ChangeSelectionCountOperation ChangeCountOf(SelectionNode selection, int newCount) =>
         new(selection, newCount);
 
-    public static AddRootEntryFromSymbol AddRootEntryFromSymbol(ISelectionEntryContainerSymbol link, string force, int count = 1) =>
-        new(link, force, count);
+    public static AddRootEntryFromSymbol AddRootEntryFromSymbol(ISelectionEntryContainerSymbol entry, string force, int count = 1) =>
+        new(SymbolKey.Create(entry), force, count);
 }
 
 public sealed class IdentityRosterOperation : IRosterOperation
@@ -185,21 +185,19 @@ public record AddSelectionFromLinkOp(SelectionEntryNode SelectionEntry, EntryLin
     }
 }
 
-public record AddRootEntryFromSymbol(ISelectionEntryContainerSymbol Entry, string ForceId, int Count = 1) : RosterOperationBase
+public record AddRootEntryFromSymbol(SymbolKey EntryKey, string ForceId, int Count = 1) : RosterOperationBase
 {
     protected override RosterOperationKind Kind => RosterOperationKind.AddSelection;
 
     protected override RosterNode TransformRoster(RosterState state)
     {
         var roster = state.RosterRequired;
-        // hack for referencing symbols from previous compilations, until SymbolReference is done
-        var entryLocal = state.Compilation.GlobalNamespace.Catalogues
-            .FirstOrDefault(x => x.Id == Entry.ContainingModule!.Id)
-            ?.RootContainerEntries
-            .Where(x => x.IsContainerKind(ContainerKind.Selection))
-            .OfType<ISelectionEntryContainerSymbol>()
-            .FirstOrDefault(x => x.Id == Entry.Id)
-            ?? throw new InvalidOperationException($"Entry '{Entry.Id}' not found in compilation.");
+        var resolution = EntryKey.Resolve(state.Compilation);
+        if (resolution.Kind != SymbolKeyResolutionKind.Resolved || resolution.Symbol is not ISelectionEntryContainerSymbol entryLocal)
+        {
+            throw new InvalidOperationException(
+                $"Entry key ({EntryKey.Kind}, '{EntryKey.SymbolId}') could not be resolved: {resolution.Kind}.");
+        }
         var entries = !entryLocal.IsReference
             ? new[] { entryLocal }
             : new[] { entryLocal, entryLocal.ReferencedEntry! };

--- a/src/WarHub.ArmouryModel.Extensions/Compilation/Compilation.cs
+++ b/src/WarHub.ArmouryModel.Extensions/Compilation/Compilation.cs
@@ -38,5 +38,11 @@ public abstract class Compilation
 
     public abstract Compilation ReplaceSourceTree(SourceTree oldTree, SourceTree? newTree);
 
+    /// <summary>
+    /// Resolves a <see cref="SymbolKey"/> in this compilation, returning the matching symbol
+    /// or a description of why resolution failed (missing or ambiguous).
+    /// </summary>
+    public abstract SymbolKeyResolution ResolveSymbolKey(SymbolKey key);
+
     internal abstract ICatalogueSymbol CreateMissingGamesystemSymbol(DiagnosticBag diagnostics);
 }

--- a/src/WarHub.ArmouryModel.Extensions/Symbols/SymbolKey.cs
+++ b/src/WarHub.ArmouryModel.Extensions/Symbols/SymbolKey.cs
@@ -1,0 +1,76 @@
+namespace WarHub.ArmouryModel;
+
+/// <summary>
+/// Lightweight, serializable identifier for an <see cref="ISymbol"/> that can be
+/// resolved across compilations built from compatible data.
+/// Analogous to Roslyn's internal SymbolKey.
+/// </summary>
+public readonly record struct SymbolKey
+{
+    /// <summary>
+    /// The kind of symbol this key identifies.
+    /// </summary>
+    public SymbolKind Kind { get; init; }
+
+    /// <summary>
+    /// The <see cref="ISymbol.Id"/> of the target symbol.
+    /// </summary>
+    public string? SymbolId { get; init; }
+
+    /// <summary>
+    /// The <see cref="ISymbol.Id"/> of the containing module
+    /// (<see cref="ICatalogueSymbol"/> or <see cref="IRosterSymbol"/>).
+    /// </summary>
+    public string? ContainingModuleId { get; init; }
+
+    /// <summary>
+    /// The <see cref="ISymbol.Id"/> of the containing entry, used to
+    /// disambiguate nested entries that might share an ID with a root entry.
+    /// <see langword="null"/> for root-level entries and top-level roster containers.
+    /// </summary>
+    public string? ContainingEntryId { get; init; }
+
+    /// <summary>
+    /// Creates a <see cref="SymbolKey"/> from the given symbol's position in the symbol hierarchy.
+    /// </summary>
+    public static SymbolKey Create(ISymbol symbol)
+    {
+        return new SymbolKey
+        {
+            Kind = symbol.Kind,
+            SymbolId = symbol.Id,
+            ContainingModuleId = symbol.ContainingModule?.Id,
+            ContainingEntryId = GetContainingEntryId(symbol),
+        };
+    }
+
+    /// <summary>
+    /// Resolves this key in the given <paramref name="compilation"/>, returning
+    /// a <see cref="SymbolKeyResolution"/> describing the outcome.
+    /// </summary>
+    public SymbolKeyResolution Resolve(Compilation compilation) =>
+        compilation.ResolveSymbolKey(this);
+
+    private static string? GetContainingEntryId(ISymbol symbol)
+    {
+        // Walk up from the symbol's immediate parent to find a containing entry
+        // that provides disambiguation context.
+        for (var parent = symbol.ContainingSymbol; parent is not null; parent = parent.ContainingSymbol)
+        {
+            switch (parent.Kind)
+            {
+                // Catalogue/Roster module boundary — no containing entry.
+                case SymbolKind.Catalogue:
+                case SymbolKind.Roster:
+                case SymbolKind.Namespace:
+                    return null;
+
+                // Immediate parent is an entry or container — use its ID.
+                case SymbolKind.ContainerEntry:
+                case SymbolKind.Container:
+                    return parent.Id;
+            }
+        }
+        return null;
+    }
+}

--- a/src/WarHub.ArmouryModel.Extensions/Symbols/SymbolKeyResolution.cs
+++ b/src/WarHub.ArmouryModel.Extensions/Symbols/SymbolKeyResolution.cs
@@ -1,0 +1,84 @@
+using System.Runtime.CompilerServices;
+
+namespace WarHub.ArmouryModel;
+
+/// <summary>
+/// Describes the result of resolving a <see cref="SymbolKey"/> against a <see cref="Compilation"/>.
+/// </summary>
+public enum SymbolKeyResolutionKind
+{
+    /// <summary>
+    /// Exactly one symbol was found.
+    /// </summary>
+    Resolved,
+
+    /// <summary>
+    /// No matching symbol was found in the compilation.
+    /// </summary>
+    Missing,
+
+    /// <summary>
+    /// Multiple matching symbols were found. See <see cref="SymbolKeyResolution.CandidateSymbols"/>.
+    /// </summary>
+    Ambiguous,
+}
+
+/// <summary>
+/// The result of resolving a <see cref="SymbolKey"/> against a <see cref="Compilation"/>.
+/// </summary>
+public readonly struct SymbolKeyResolution : IEquatable<SymbolKeyResolution>
+{
+    private SymbolKeyResolution(ISymbol? symbol, ImmutableArray<ISymbol> candidateSymbols, SymbolKeyResolutionKind kind)
+    {
+        Symbol = symbol;
+        CandidateSymbols = candidateSymbols;
+        Kind = kind;
+    }
+
+    /// <summary>
+    /// The resolved symbol, or <see langword="null"/> if resolution was not successful.
+    /// </summary>
+    public ISymbol? Symbol { get; }
+
+    /// <summary>
+    /// When <see cref="Kind"/> is <see cref="SymbolKeyResolutionKind.Ambiguous"/>,
+    /// contains the candidate symbols that matched.
+    /// </summary>
+    public ImmutableArray<ISymbol> CandidateSymbols { get; }
+
+    /// <summary>
+    /// Describes the outcome of the resolution.
+    /// </summary>
+    public SymbolKeyResolutionKind Kind { get; }
+
+    /// <summary>
+    /// Creates a successful resolution with exactly one symbol.
+    /// </summary>
+    public static SymbolKeyResolution Resolved(ISymbol symbol) =>
+        new(symbol, ImmutableArray<ISymbol>.Empty, SymbolKeyResolutionKind.Resolved);
+
+    /// <summary>
+    /// Creates a missing resolution (no matching symbol found).
+    /// </summary>
+    public static SymbolKeyResolution Missing() =>
+        new(null, ImmutableArray<ISymbol>.Empty, SymbolKeyResolutionKind.Missing);
+
+    /// <summary>
+    /// Creates an ambiguous resolution with multiple candidates.
+    /// </summary>
+    public static SymbolKeyResolution Ambiguous(ImmutableArray<ISymbol> candidates) =>
+        new(null, candidates, SymbolKeyResolutionKind.Ambiguous);
+
+    public bool Equals(SymbolKeyResolution other) =>
+        Kind == other.Kind
+        && ReferenceEquals(Symbol, other.Symbol)
+        && CandidateSymbols.SequenceEqual(other.CandidateSymbols);
+
+    public override bool Equals(object? obj) => obj is SymbolKeyResolution other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(Kind, RuntimeHelpers.GetHashCode(Symbol));
+
+    public static bool operator ==(SymbolKeyResolution left, SymbolKeyResolution right) => left.Equals(right);
+
+    public static bool operator !=(SymbolKeyResolution left, SymbolKeyResolution right) => !left.Equals(right);
+}

--- a/tests/WarHub.ArmouryModel.Concrete.Extensions.Tests/SymbolKeyTests.cs
+++ b/tests/WarHub.ArmouryModel.Concrete.Extensions.Tests/SymbolKeyTests.cs
@@ -1,0 +1,389 @@
+using FluentAssertions;
+using Phalanx.SampleDataset;
+using WarHub.ArmouryModel.Concrete;
+using WarHub.ArmouryModel.Source;
+using Xunit;
+
+namespace WarHub.ArmouryModel;
+
+public class SymbolKeyTests
+{
+    #region Round-trip: same compilation
+
+    [Fact]
+    public void Catalogue_symbol_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+
+        var key = SymbolKey.Create(catalogue);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(catalogue);
+    }
+
+    [Fact]
+    public void Root_container_entry_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        var rootEntry = catalogue.RootContainerEntries.First();
+
+        var key = SymbolKey.Create(rootEntry);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(rootEntry);
+    }
+
+    [Fact]
+    public void Nested_container_entry_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        var rootEntry = catalogue.RootContainerEntries
+            .OfType<ISelectionEntryContainerSymbol>()
+            .FirstOrDefault(x => x.ChildSelectionEntries.Length > 0);
+        if (rootEntry is null)
+        {
+            // Try shared entries if no root entry has children.
+            rootEntry = catalogue.SharedSelectionEntryContainers
+                .FirstOrDefault(x => x.ChildSelectionEntries.Length > 0);
+        }
+        rootEntry.Should().NotBeNull("Sample dataset should have a nested entry");
+        var nestedEntry = rootEntry!.ChildSelectionEntries.First();
+
+        var key = SymbolKey.Create(nestedEntry);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(nestedEntry);
+    }
+
+    [Fact]
+    public void Resource_definition_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var gamesystem = compilation.GlobalNamespace.RootCatalogue;
+        var resDef = gamesystem.ResourceDefinitions.First();
+
+        var key = SymbolKey.Create(resDef);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(resDef);
+    }
+
+    [Fact]
+    public void Resource_entry_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        // Find any resource entry with a non-null ID - search shared entries too.
+        var entry = catalogue.SharedSelectionEntryContainers
+            .SelectMany(x => x.Resources)
+            .Concat(catalogue.RootContainerEntries
+                .OfType<ISelectionEntryContainerSymbol>()
+                .SelectMany(x => x.Resources))
+            .Concat(catalogue.RootResourceEntries)
+            .First(r => r.Id is not null);
+
+        var key = SymbolKey.Create(entry);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(entry);
+    }
+
+    [Fact]
+    public void Roster_symbol_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var roster = compilation.GlobalNamespace.Rosters.First();
+
+        var key = SymbolKey.Create(roster);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(roster);
+    }
+
+    [Fact]
+    public void Roster_force_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var force = compilation.GlobalNamespace.Rosters.First().Forces.First();
+
+        var key = SymbolKey.Create(force);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(force);
+    }
+
+    [Fact]
+    public void Roster_selection_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var selection = compilation.GlobalNamespace.Rosters.First()
+            .Forces.First()
+            .Selections.First();
+
+        var key = SymbolKey.Create(selection);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(selection);
+    }
+
+    [Fact]
+    public void Entry_link_round_trips()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        var entryLink = catalogue.RootContainerEntries
+            .OfType<ISelectionEntryContainerSymbol>()
+            .First(x => x.IsReference);
+
+        var key = SymbolKey.Create(entryLink);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(entryLink);
+    }
+
+    #endregion
+
+    #region Round-trip: across recompilation
+
+    [Fact]
+    public void Catalogue_entry_resolves_in_recompiled_compilation()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        var rootEntry = catalogue.RootContainerEntries.First();
+
+        var key = SymbolKey.Create(rootEntry);
+
+        // Rebuild compilation from the same source trees.
+        var newCompilation = WhamCompilation.Create(compilation.SourceTrees);
+        var resolution = key.Resolve(newCompilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().NotBeSameAs(rootEntry, "New compilation has new symbol instances");
+        resolution.Symbol!.Id.Should().Be(rootEntry.Id);
+        resolution.Symbol.Kind.Should().Be(rootEntry.Kind);
+    }
+
+    [Fact]
+    public void Roster_force_resolves_in_recompiled_compilation()
+    {
+        var compilation = CreateSampleCompilation();
+        var force = compilation.GlobalNamespace.Rosters.First().Forces.First();
+
+        var key = SymbolKey.Create(force);
+
+        var newCompilation = WhamCompilation.Create(compilation.SourceTrees);
+        var resolution = key.Resolve(newCompilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().NotBeSameAs(force);
+        resolution.Symbol!.Id.Should().Be(force.Id);
+    }
+
+    #endregion
+
+    #region Edge cases
+
+    [Fact]
+    public void Resolve_in_empty_compilation_returns_Missing()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        var key = SymbolKey.Create(catalogue);
+
+        var emptyCompilation = WhamCompilation.Create();
+        var resolution = key.Resolve(emptyCompilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Missing);
+        resolution.Symbol.Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_after_removing_source_tree_returns_Missing()
+    {
+        var compilation = CreateSampleCompilation();
+        var roster = compilation.GlobalNamespace.Rosters.First();
+        var key = SymbolKey.Create(roster);
+
+        // Remove the roster's source tree.
+        var rosterTree = compilation.SourceTrees.First(t =>
+            t.GetRoot() is RosterNode);
+        var withoutRoster = compilation.ReplaceSourceTree(rosterTree, null);
+        var resolution = key.Resolve(withoutRoster);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Missing);
+    }
+
+    [Fact]
+    public void SymbolKey_with_default_values_resolves_to_Missing()
+    {
+        var compilation = CreateSampleCompilation();
+        var key = default(SymbolKey);
+
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Missing);
+    }
+
+    [Fact]
+    public void SymbolKey_equality_same_fields_are_equal()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+
+        var key1 = SymbolKey.Create(catalogue);
+        var key2 = SymbolKey.Create(catalogue);
+
+        key1.Should().Be(key2);
+    }
+
+    [Fact]
+    public void SymbolKey_equality_different_symbols_are_not_equal()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogues = compilation.GlobalNamespace.Catalogues;
+        var cat1 = catalogues.First(x => x.IsGamesystem);
+        var cat2 = catalogues.First(x => !x.IsGamesystem);
+
+        var key1 = SymbolKey.Create(cat1);
+        var key2 = SymbolKey.Create(cat2);
+
+        key1.Should().NotBe(key2);
+    }
+
+    [Fact]
+    public void Create_captures_correct_fields_for_catalogue_entry()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        var rootEntry = catalogue.RootContainerEntries.First();
+
+        var key = SymbolKey.Create(rootEntry);
+
+        key.Kind.Should().Be(SymbolKind.ContainerEntry);
+        key.SymbolId.Should().Be(rootEntry.Id);
+        key.ContainingModuleId.Should().Be(catalogue.Id);
+        key.ContainingEntryId.Should().BeNull("Root entries have no containing entry");
+    }
+
+    [Fact]
+    public void Create_captures_correct_fields_for_nested_entry()
+    {
+        var compilation = CreateSampleCompilation();
+        var catalogue = compilation.GlobalNamespace.Catalogues.First(x => !x.IsGamesystem);
+        var rootEntry = catalogue.SharedSelectionEntryContainers
+            .First(x => x.ChildSelectionEntries.Length > 0);
+        var nestedEntry = rootEntry.ChildSelectionEntries.First();
+
+        var key = SymbolKey.Create(nestedEntry);
+
+        key.Kind.Should().Be(SymbolKind.ContainerEntry);
+        key.SymbolId.Should().Be(nestedEntry.Id);
+        key.ContainingModuleId.Should().Be(catalogue.Id);
+        key.ContainingEntryId.Should().Be(rootEntry.Id, "Nested entry's containing entry is the parent");
+    }
+
+    [Fact]
+    public void Create_captures_correct_fields_for_roster_selection()
+    {
+        var compilation = CreateSampleCompilation();
+        var roster = compilation.GlobalNamespace.Rosters.First();
+        var force = roster.Forces.First();
+        var selection = force.Selections.First();
+
+        var key = SymbolKey.Create(selection);
+
+        key.Kind.Should().Be(SymbolKind.Container);
+        key.SymbolId.Should().Be(selection.Id);
+        key.ContainingModuleId.Should().Be(roster.Id);
+        key.ContainingEntryId.Should().Be(force.Id, "Selection's containing entry is the force");
+    }
+
+    #endregion
+
+    #region Simple compilation tests
+
+    [Fact]
+    public void Round_trip_with_simple_catalogue()
+    {
+        var gst = NodeFactory.Gamesystem("foo");
+        var cat = NodeFactory.Catalogue(gst, "bar")
+            .AddSelectionEntries(
+                NodeFactory.SelectionEntry("entry").Tee(out var entry));
+        var compilation = WhamCompilation.Create(
+            [SourceTree.CreateForRoot(gst), SourceTree.CreateForRoot(cat)]);
+        compilation.GetDiagnostics().Should().BeEmpty();
+
+        var catalogue = compilation.GlobalNamespace.Catalogues.Single(x => !x.IsGamesystem);
+        var entrySymbol = catalogue.RootContainerEntries.Single();
+
+        var key = SymbolKey.Create(entrySymbol);
+        var resolution = key.Resolve(compilation);
+
+        resolution.Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        resolution.Symbol.Should().BeSameAs(entrySymbol);
+    }
+
+    [Fact]
+    public void Round_trip_with_simple_roster()
+    {
+        var gst = NodeFactory.Gamesystem("foo")
+            .AddForceEntries(NodeFactory.ForceEntry("detachment").Tee(out var forceEntry));
+        var selEntry = NodeFactory.SelectionEntry("unit").Tee(out var selEntryNode);
+        var cat = NodeFactory.Catalogue(gst, "bar")
+            .AddSelectionEntries(selEntry);
+        var roster = NodeFactory.Roster(gst)
+            .AddForces(
+                NodeFactory.Force(forceEntry, gst).Tee(out var forceNode)
+                    .AddSelections(
+                        NodeFactory.Selection(selEntryNode, selEntryNode.Id!)));
+        var compilation = WhamCompilation.Create(
+            [SourceTree.CreateForRoot(gst), SourceTree.CreateForRoot(cat), SourceTree.CreateForRoot(roster)]);
+
+        var rosterSymbol = compilation.GlobalNamespace.Rosters.Single();
+        var forceSymbol = rosterSymbol.Forces.Single();
+        var selectionSymbol = forceSymbol.Selections.Single();
+
+        // Round-trip roster
+        var rosterKey = SymbolKey.Create(rosterSymbol);
+        rosterKey.Resolve(compilation).Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        rosterKey.Resolve(compilation).Symbol.Should().BeSameAs(rosterSymbol);
+
+        // Round-trip force
+        var forceKey = SymbolKey.Create(forceSymbol);
+        forceKey.Resolve(compilation).Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        forceKey.Resolve(compilation).Symbol.Should().BeSameAs(forceSymbol);
+
+        // Round-trip selection
+        var selectionKey = SymbolKey.Create(selectionSymbol);
+        selectionKey.Resolve(compilation).Kind.Should().Be(SymbolKeyResolutionKind.Resolved);
+        selectionKey.Resolve(compilation).Symbol.Should().BeSameAs(selectionSymbol);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static WhamCompilation CreateSampleCompilation()
+    {
+        var xmlWorkspace = SampleDataResources.CreateXmlWorkspace();
+        return WhamCompilation.Create(
+#pragma warning disable xUnit1031
+            xmlWorkspace.Documents.Select(x => SourceTree.CreateForRoot(x.GetRootAsync().Result!)).ToImmutableArray());
+#pragma warning restore xUnit1031
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Phase 1: SymbolKey — Cross-compilation symbol identity

Closes #280 | Parent epic: #279

### Problem

When a roster edit creates a new `WhamCompilation`, all old `ISymbol` instances become stale. Editor operations that reference symbols from a previous compilation must manually re-find them by duplicating binding/lookup logic (see hacks in `RosterOperations.cs` lines 177-202).

### Solution

Roslyn-inspired `SymbolKey` mechanism — a lightweight, serializable identifier for any `ISymbol` that can be resolved in a different `Compilation` built from compatible data.

### Changes

- **`SymbolKey`** readonly record struct in `Extensions/Symbols/` — `Create(ISymbol)` + `Resolve(Compilation)`
- **`SymbolKeyResolution`** + **`SymbolKeyResolutionKind`** — resolution result types (Resolved/Missing/Ambiguous)
- **`SymbolIndex`** internal class in `Concrete.Extensions` — lazy per-compilation O(1) index for symbol lookup
- **Abstract `ResolveSymbolKey()`** on `Compilation` base, implemented in `WhamCompilation`
- **EditorServices refactor** — replace manual ID-based lookup hacks with `SymbolKey`
- **Tests** — round-trip for all symbol types, edge cases (Missing, Ambiguous, cross-recompilation)