### PR TITLE
perf: short-circuit effective processing when Effects are empty

### DIFF
--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/EffectiveEntryCache.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/EffectiveEntryCache.cs
@@ -235,6 +235,8 @@ internal sealed class EffectiveEntryCache
         ISelectionSymbol? selection,
         IForceSymbol? force)
     {
+        if (entry.Effects.IsEmpty)
+            return cost;
         var effectiveValue = Evaluator.GetEffectiveCostValue(cost, entry, selection, force);
         if (effectiveValue != cost.Value)
             return new EffectiveCostSymbol(cost, effectiveValue);
@@ -256,6 +258,34 @@ internal sealed class EffectiveEntryCache
         ISelectionSymbol? selection,
         IForceSymbol? force)
     {
+        // Determine name and hidden from link/group overrides (property-based, not effect-based).
+        bool hidden;
+        string name;
+        if (linkOverridesProfile && link is not null)
+        {
+            // MapProfileNodeWithOverrides: link.Hidden || (group?.Hidden ?? profile.Hidden)
+            var baseHidden = group?.IsHidden ?? profile.IsHidden;
+            hidden = link.IsHidden || baseHidden;
+            name = !string.IsNullOrEmpty(link.Name) ? link.Name : profile.Name ?? "";
+        }
+        else
+        {
+            // MapProfileNode: group?.Hidden ?? profile.Hidden; name from profile only
+            hidden = group?.IsHidden ?? profile.IsHidden;
+            name = profile.Name ?? "";
+        }
+
+        // Short-circuit: when no entry in the chain has effects, skip characteristic evaluation.
+        var chainHasEffects = !profile.Effects.IsEmpty
+            || (link is not null && !link.Effects.IsEmpty)
+            || (group is not null && !group.Effects.IsEmpty);
+        if (!chainHasEffects)
+        {
+            if (name == profile.Name && hidden == profile.IsHidden)
+                return profile;
+            return new EffectiveProfileSymbol(profile, name, hidden, profile.Characteristics);
+        }
+
         // Build characteristics with modifier chain: profile → link → group.
         var anyCharChanged = false;
         var chars = ImmutableArray.CreateBuilder<ICharacteristicSymbol>(profile.Characteristics.Length);
@@ -280,22 +310,6 @@ internal sealed class EffectiveEntryCache
             }
         }
 
-        bool hidden;
-        string name;
-        if (linkOverridesProfile && link is not null)
-        {
-            // MapProfileNodeWithOverrides: link.Hidden || (group?.Hidden ?? profile.Hidden)
-            var baseHidden = group?.IsHidden ?? profile.IsHidden;
-            hidden = link.IsHidden || baseHidden;
-            name = !string.IsNullOrEmpty(link.Name) ? link.Name : profile.Name ?? "";
-        }
-        else
-        {
-            // MapProfileNode: group?.Hidden ?? profile.Hidden; name from profile only
-            hidden = group?.IsHidden ?? profile.IsHidden;
-            name = profile.Name ?? "";
-        }
-
         if (!anyCharChanged && name == profile.Name && hidden == profile.IsHidden)
             return profile;
 
@@ -318,14 +332,7 @@ internal sealed class EffectiveEntryCache
         ISelectionSymbol? selection,
         IForceSymbol? force)
     {
-        // Apply description modifiers: rule → link → group.
-        var desc = rule.DescriptionText;
-        desc = Evaluator.GetEffectiveRuleDescription(rule, desc, selection, force);
-        if (link is not null)
-            desc = Evaluator.GetEffectiveRuleDescription(link, desc, selection, force);
-        if (group is not null)
-            desc = Evaluator.GetEffectiveRuleDescription(group, desc, selection, force);
-
+        // Determine name and hidden from link/group overrides (property-based, not effect-based).
         bool hidden;
         string name;
         if (linkOverridesProfile && link is not null)
@@ -339,6 +346,25 @@ internal sealed class EffectiveEntryCache
             hidden = group?.IsHidden ?? rule.IsHidden;
             name = rule.Name ?? "";
         }
+
+        // Short-circuit: when no entry in the chain has effects, skip description evaluation.
+        var chainHasEffects = !rule.Effects.IsEmpty
+            || (link is not null && !link.Effects.IsEmpty)
+            || (group is not null && !group.Effects.IsEmpty);
+        if (!chainHasEffects)
+        {
+            if (name == rule.Name && hidden == rule.IsHidden)
+                return rule;
+            return new EffectiveRuleSymbol(rule, name, hidden, rule.DescriptionText);
+        }
+
+        // Apply description modifiers: rule → link → group.
+        var desc = rule.DescriptionText;
+        desc = Evaluator.GetEffectiveRuleDescription(rule, desc, selection, force);
+        if (link is not null)
+            desc = Evaluator.GetEffectiveRuleDescription(link, desc, selection, force);
+        if (group is not null)
+            desc = Evaluator.GetEffectiveRuleDescription(group, desc, selection, force);
 
         if (desc == rule.DescriptionText && name == rule.Name && hidden == rule.IsHidden)
             return rule;

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
@@ -37,6 +37,8 @@ internal sealed class ModifierEvaluator
     public string GetEffectiveName(IEntrySymbol entry, ISelectionSymbol? selection, IForceSymbol? force)
     {
         var name = entry.Name ?? "";
+        if (entry.Effects.IsEmpty)
+            return name;
         var context = new EvalContext(selection, force, entry);
         foreach (var effect in entry.Effects)
         {
@@ -51,6 +53,8 @@ internal sealed class ModifierEvaluator
     public bool GetEffectiveHidden(IEntrySymbol entry, ISelectionSymbol? selection, IForceSymbol? force)
     {
         var hidden = entry.IsHidden;
+        if (entry.Effects.IsEmpty)
+            return hidden;
         var context = new EvalContext(selection, force, entry);
         foreach (var effect in entry.Effects)
         {
@@ -74,6 +78,8 @@ internal sealed class ModifierEvaluator
             if (constraint.Id is not null)
                 values[constraint.Id] = constraint.Query.ReferenceValue ?? 0m;
         }
+        if (entry.Effects.IsEmpty)
+            return values;
         var context = new EvalContext(selection, force, entry);
         foreach (var effect in entry.Effects)
         {
@@ -92,7 +98,7 @@ internal sealed class ModifierEvaluator
         IForceSymbol? force)
     {
         var typeId = cost.Type?.Id;
-        if (typeId is null)
+        if (typeId is null || entry.Effects.IsEmpty)
             return cost.Value;
         var value = cost.Value;
         var context = new EvalContext(selection, force, entry);
@@ -113,6 +119,8 @@ internal sealed class ModifierEvaluator
         ISelectionSymbol? selection,
         IForceSymbol? force)
     {
+        if (profileEntry.Effects.IsEmpty)
+            return currentValue;
         var value = currentValue;
         var context = new EvalContext(selection, force, profileEntry);
         foreach (var effect in profileEntry.Effects)
@@ -128,6 +136,8 @@ internal sealed class ModifierEvaluator
     /// </summary>
     public string? GetEffectivePage(IEntrySymbol entry, ISelectionSymbol? selection, IForceSymbol? force)
     {
+        if (entry.Effects.IsEmpty)
+            return null;
         string? page = null;
         var context = new EvalContext(selection, force, entry);
         foreach (var effect in entry.Effects)
@@ -169,6 +179,8 @@ internal sealed class ModifierEvaluator
         ISelectionSymbol? selection,
         IForceSymbol? force)
     {
+        if (ruleEntry.Effects.IsEmpty)
+            return currentDescription;
         var desc = currentDescription;
         var context = new EvalContext(selection, force, ruleEntry);
         foreach (var effect in ruleEntry.Effects)
@@ -224,6 +236,8 @@ internal sealed class ModifierEvaluator
         if (primarySym is not null)
             primaryId = primarySym.ReferencedEntry?.Id ?? primarySym.Id;
 
+        if (entry.Effects.IsEmpty)
+            return (categories, primaryId);
         var context = new EvalContext(selection, force, entry);
         foreach (var effect in entry.Effects)
         {
@@ -246,6 +260,8 @@ internal sealed class ModifierEvaluator
         var categories = new List<string>(initialCategoryIds);
         string? primaryId = initialPrimaryId;
 
+        if (entry.Effects.IsEmpty)
+            return (categories, primaryId);
         var context = new EvalContext(selection, force, entry);
         foreach (var effect in entry.Effects)
         {


### PR DESCRIPTION
## Summary

Skip expensive modifier evaluation when entries in the modifier chain have no Effects.

### Tier 1 — ModifierEvaluator early returns
Add \Effects.IsEmpty\ guards at the top of all 9 \GetEffective*\ methods to avoid \EvalContext\ creation and empty-loop iteration.

### Tier 2 — Resource chain short-circuit  
In \BuildEffectiveProfile\/\BuildEffectiveRule\/\BuildEffectiveCost\, check if all entries in the modifier chain (profile/rule, link, group) have empty Effects before iterating characteristics/descriptions. When effect-free, only apply link/group name+hidden overrides (which are property-based, not effect-based).

### Rationale
- \ntry.Effects.IsEmpty\ is O(1) — Effects is an eagerly-computed \ImmutableArray\.
- In typical data, most profiles/rules/infoLinks/infoGroups are effect-free — modifiers cluster on selection entries and force entries.
- A profile with 6 characteristics and a 3-level chain (profile→link→group) triggers 18 \GetEffectiveCharacteristic\ calls that are all no-ops when effects are empty.

### Testing
All 712 tests pass including 304 conformance specs.
