### PR TITLE
refactor: self-completing symbol properties (Roslyn-style)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,9 @@ WhamRosterEngine (IRosterEngine)
     └── ModifierEvaluator      — apply modifiers, evaluate conditions, resolve scopes
 
 Symbol completion pipeline (CompletionPart phases):
-  BindReferences → Members → EffectiveEntries → Constraints
-  (RosterSymbol overrides EffectiveEntries + Constraints phases)
+  Members → MembersCompleted → EffectiveEntries → CheckReferences → CheckConstraints
+  (Bound reference fields are self-completing via Interlocked.CompareExchange)
+  (RosterSymbol overrides EffectiveEntries + CheckConstraints phases)
 
 ConstraintEvaluator (Concrete.Extensions) — symbol-layer constraint validation
 StateMapper (RosterEngine.Spec) — thin Symbol→Protocol mapper (~140 LOC)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/docs/roster-editing-analysis.md
+++ b/docs/roster-editing-analysis.md
@@ -144,17 +144,22 @@ conditioned on roster state).
 Symbol completion follows a 4-phase pipeline managed by `SymbolCompletionState`:
 
 ```
-Phase 1: BindReferences          ← resolve IDs via Binder chain
-Phase 2: Members                 ← collect/initialize child symbols
-Phase 3: EffectiveEntries        ← compute modifier-applied values (roster-only)
-Phase 4: Constraints             ← evaluate constraint diagnostics (roster-only)
+Phase 1: Members                 ← collect/initialize child symbols
+Phase 2: EffectiveEntries        ← compute modifier-applied values (roster-only)
+Phase 3: CheckReferences         ← force-access bound fields, report diagnostics
+Phase 4: CheckConstraints        ← evaluate constraint diagnostics (roster-only)
 ```
 
-Phases 3–4 are **roster-only** — catalogue symbols auto-complete these phases immediately
-since effective entries require roster context for condition evaluation.
+Bound reference fields (e.g. `Type`, `Publication`, `SourceEntry`) are
+**self-completing** — each property getter lazily binds on first access using
+`Interlocked.CompareExchange`. There is no separate `BindReferences` phase.
+`CheckReferences` force-accesses all bound fields to ensure diagnostics are reported.
+
+Phases 2 and 4 are **roster-only** — catalogue symbols auto-complete these phases
+immediately since effective entries require roster context for condition evaluation.
 
 **Trigger**: `ForceComplete()` on any symbol cascades through all phases. Accessing
-`ISelectionSymbol.EffectiveSourceEntry` triggers completion up through Phase 3.
+`ISelectionSymbol.EffectiveSourceEntry` triggers completion up through Phase 2.
 `GetDiagnostics()` triggers full completion including Phase 4.
 
 #### 3c. EffectiveEntryCache Architecture

--- a/docs/roster-engine.md
+++ b/docs/roster-engine.md
@@ -29,7 +29,8 @@ decision record.
 │   Concrete.Extensions (symbols + effective wrappers)     │
 │   ModifierEvaluator + EffectiveEntryCache (internal)     │
 │   ConstraintEvaluator (internal)                         │
-│   CompletionPart pipeline (EffectiveEntries, Constraints)│
+│   CompletionPart pipeline (Members, EffectiveEntries,    │
+│     CheckReferences, CheckConstraints)                   │
 │   Extensions (public ISymbol interfaces)                 │
 │   Source (DTO types, SourceNode trees)                   │
 └──────────────────────────────────────────────────────────┘
@@ -134,7 +135,7 @@ Evaluates modifiers and conditions using IEffectSymbol/IConditionSymbol:
 
 > **Note**: `ConstraintValidator` in RosterEngine.Spec is the legacy node-layer
 > validator. Constraint evaluation is now performed by `ConstraintEvaluator` in
-> Concrete.Extensions as part of the `CompletionPart.Constraints` phase.
+> Concrete.Extensions as part of the `CompletionPart.CheckConstraints` phase.
 > The adapter's `GetValidationErrors()` reads from
 > `compilation.GetConstraintDiagnostics()`.
 
@@ -170,13 +171,19 @@ flags enum. Each phase has `Start`/`Finish` pairs with CAS-protected
 once-only execution:
 
 ```
-Phase 0-1: BindReferences     — resolve IDs to symbols (all symbols)
-Phase 2-3: Members             — compute GetMembers() (all symbols)
-Phase 4-5: EffectiveEntries    — compute effective entry symbols (RosterSymbol only)
-Phase 6-7: Constraints         — evaluate constraint diagnostics (RosterSymbol only)
+Phase 0-1: Members             — compute GetMembers() (all symbols)
+Phase 2-3: EffectiveEntries    — compute effective entry symbols (RosterSymbol only)
+Phase 4-5: CheckReferences     — force-access bound fields, report diagnostics (all symbols)
+Phase 6-7: CheckConstraints    — evaluate constraint diagnostics (RosterSymbol only)
 ```
 
-Non-roster symbols auto-complete phases 4-7 in the base virtual methods.
+Bound reference fields (e.g. `Type`, `Publication`, `SourceEntry`) are
+**self-completing**: each property getter lazily binds on first access using
+`Interlocked.CompareExchange`, so there is no separate `BindReferences` phase.
+The `CheckReferences` phase force-accesses all bound fields to ensure binding
+diagnostics are reported during `ForceComplete`.
+
+Non-roster symbols auto-complete phases 2-7 in the base virtual methods.
 `RosterSymbol` overrides `ComputeEffectiveEntries()` and
 `EvaluateConstraints()` to perform actual work.
 
@@ -185,7 +192,7 @@ Non-roster symbols auto-complete phases 4-7 in the base virtual methods.
 2. Create `EffectiveEntryCache` for the roster
 3. Walk force→selection tree, eagerly populate `SelectionSymbol.lazyEffectiveSourceEntry`
 
-**Constraints phase** (`RosterSymbol.EvaluateConstraints`):
+**CheckConstraints phase** (`RosterSymbol.EvaluateConstraints`):
 1. Call `ConstraintEvaluator.Evaluate(roster, compilation, diagnosticBag)`
 2. Diagnostics are stored in `WhamCompilation.ConstraintDiagnostics`
 3. Accessed via `compilation.GetConstraintDiagnostics()`
@@ -244,7 +251,7 @@ src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/
 └── ConstraintEvaluator.cs        (~810 lines, internal, symbol-layer constraints)
 
 src/WarHub.ArmouryModel.Concrete.Extensions/Utilities/
-└── CompletionPart.cs             (8-bit flags enum, phases 0-7)
+└── CompletionPart.cs             (8-bit flags enum: Members, EffectiveEntries, CheckReferences, CheckConstraints)
 
 src/WarHub.ArmouryModel.RosterEngine/
 ├── WhamRosterEngine.cs      (~790 lines)

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueReferenceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueReferenceSymbol.cs
@@ -18,7 +18,10 @@ internal sealed class CatalogueReferenceSymbol : SourceDeclaredSymbol, ICatalogu
 
     public int CatalogueRevision => default;
 
-    public ICatalogueSymbol Catalogue => GetBoundField(ref lazyCatalogue);
+    public ICatalogueSymbol Catalogue =>
+        GetBoundField(ref lazyCatalogue, (b, d) => b.BindCatalogueSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Catalogue;
 
     public override CatalogueLinkNode Declaration { get; }
 
@@ -30,11 +33,4 @@ internal sealed class CatalogueReferenceSymbol : SourceDeclaredSymbol, ICatalogu
 
     public override TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
         visitor.VisitCatalogueReference(this, argument);
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyCatalogue = binder.BindCatalogueSymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueReferenceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueReferenceSymbol.cs
@@ -19,7 +19,7 @@ internal sealed class CatalogueReferenceSymbol : SourceDeclaredSymbol, ICatalogu
     public int CatalogueRevision => default;
 
     public ICatalogueSymbol Catalogue =>
-        GetBoundField(ref lazyCatalogue, (b, d) => b.BindCatalogueSymbol(Declaration, d));
+        GetBoundField(ref lazyCatalogue, Declaration, static (b, d, decl) => b.BindCatalogueSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Catalogue;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueSymbol.cs
@@ -30,16 +30,12 @@ internal sealed class CatalogueSymbol : CatalogueBaseSymbol, INodeDeclaredSymbol
 
     public override bool IsGamesystem => false;
 
-    public override ICatalogueSymbol Gamesystem => GetBoundField(ref lazyGamesystem);
+    public override ICatalogueSymbol Gamesystem =>
+        GetBoundField(ref lazyGamesystem, (b, d) => b.BindGamesystemSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Gamesystem;
 
     public override ImmutableArray<CatalogueReferenceSymbol> CatalogueReferences { get; }
 
     CatalogueNode INodeDeclaredSymbol<CatalogueNode>.Declaration => Declaration;
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyGamesystem = binder.BindGamesystemSymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CatalogueSymbol.cs
@@ -31,7 +31,7 @@ internal sealed class CatalogueSymbol : CatalogueBaseSymbol, INodeDeclaredSymbol
     public override bool IsGamesystem => false;
 
     public override ICatalogueSymbol Gamesystem =>
-        GetBoundField(ref lazyGamesystem, (b, d) => b.BindGamesystemSymbol(Declaration, d));
+        GetBoundField(ref lazyGamesystem, Declaration, static (b, d, decl) => b.BindGamesystemSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Gamesystem;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategoryLinkSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategoryLinkSymbol.cs
@@ -19,14 +19,10 @@ internal sealed class CategoryLinkSymbol : ContainerEntryBaseSymbol, ICategoryEn
 
     public bool IsPrimaryCategory => Declaration.Primary;
 
-    public override ICategoryEntrySymbol ReferencedEntry => GetBoundField(ref lazyReference);
+    public override ICategoryEntrySymbol ReferencedEntry =>
+        GetBoundField(ref lazyReference, (b, d) => b.BindCategoryEntrySymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = ReferencedEntry;
 
     public override CategoryLinkNode Declaration { get; }
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyReference = binder.BindCategoryEntrySymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategoryLinkSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategoryLinkSymbol.cs
@@ -20,7 +20,7 @@ internal sealed class CategoryLinkSymbol : ContainerEntryBaseSymbol, ICategoryEn
     public bool IsPrimaryCategory => Declaration.Primary;
 
     public override ICategoryEntrySymbol ReferencedEntry =>
-        GetBoundField(ref lazyReference, (b, d) => b.BindCategoryEntrySymbol(Declaration, d));
+        GetBoundField(ref lazyReference, Declaration, static (b, d, decl) => b.BindCategoryEntrySymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = ReferencedEntry;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategorySymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategorySymbol.cs
@@ -17,15 +17,12 @@ internal sealed class CategorySymbol : ContainerSymbol, ICategorySymbol, INodeDe
 
     public new CategoryNode Declaration { get; }
 
-    public override ICategoryEntrySymbol SourceEntry => GetBoundField(ref lazyCategoryEntry);
+    public override ICategoryEntrySymbol SourceEntry =>
+        GetBoundField(ref lazyCategoryEntry, (b, d) => b.BindCategoryEntrySymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = SourceEntry;
 
     public override ContainerKind ContainerKind => ContainerKind.Category;
 
     public bool IsPrimaryCategory => Declaration.Primary;
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        lazyCategoryEntry = binder.BindCategoryEntrySymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategorySymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CategorySymbol.cs
@@ -18,7 +18,7 @@ internal sealed class CategorySymbol : ContainerSymbol, ICategorySymbol, INodeDe
     public new CategoryNode Declaration { get; }
 
     public override ICategoryEntrySymbol SourceEntry =>
-        GetBoundField(ref lazyCategoryEntry, (b, d) => b.BindCategoryEntrySymbol(Declaration, d));
+        GetBoundField(ref lazyCategoryEntry, Declaration, static (b, d, decl) => b.BindCategoryEntrySymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = SourceEntry;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CharacteristicSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CharacteristicSymbol.cs
@@ -19,14 +19,10 @@ internal sealed class CharacteristicSymbol : ResourceEntryBaseSymbol, ICharacter
 
     public override ResourceKind ResourceKind => ResourceKind.Characteristic;
 
-    public override IResourceDefinitionSymbol Type => GetBoundField(ref lazyType);
+    public override IResourceDefinitionSymbol Type =>
+        GetBoundField(ref lazyType, (b, d) => b.BindCharacteristicTypeSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Type;
 
     public string Value => Declaration.Value ?? string.Empty;
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyType = binder.BindCharacteristicTypeSymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CharacteristicSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CharacteristicSymbol.cs
@@ -20,7 +20,7 @@ internal sealed class CharacteristicSymbol : ResourceEntryBaseSymbol, ICharacter
     public override ResourceKind ResourceKind => ResourceKind.Characteristic;
 
     public override IResourceDefinitionSymbol Type =>
-        GetBoundField(ref lazyType, (b, d) => b.BindCharacteristicTypeSymbol(Declaration, d));
+        GetBoundField(ref lazyType, Declaration, static (b, d, decl) => b.BindCharacteristicTypeSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Type;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CostSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CostSymbol.cs
@@ -20,7 +20,7 @@ internal sealed class CostSymbol : ResourceEntryBaseSymbol, ICostSymbol, INodeDe
     public override ResourceKind ResourceKind => ResourceKind.Cost;
 
     public override IResourceDefinitionSymbol Type =>
-        GetBoundField(ref lazyTypeSymbol, (b, d) => b.BindCostTypeSymbol(Declaration, d));
+        GetBoundField(ref lazyTypeSymbol, Declaration, static (b, d, decl) => b.BindCostTypeSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Type;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CostSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/CostSymbol.cs
@@ -19,14 +19,10 @@ internal sealed class CostSymbol : ResourceEntryBaseSymbol, ICostSymbol, INodeDe
 
     public override ResourceKind ResourceKind => ResourceKind.Cost;
 
-    public override IResourceDefinitionSymbol Type => GetBoundField(ref lazyTypeSymbol);
+    public override IResourceDefinitionSymbol Type =>
+        GetBoundField(ref lazyTypeSymbol, (b, d) => b.BindCostTypeSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Type;
 
     public decimal Value => Declaration.Value;
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyTypeSymbol = binder.BindCostTypeSymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/EntryReferencePathSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/EntryReferencePathSymbol.cs
@@ -22,7 +22,10 @@ internal abstract class EntryReferencePathBaseSymbol : SourceDeclaredSymbol, IEn
 
     public sealed override SymbolKind Kind => SymbolKind.Link;
 
-    public ImmutableArray<IEntrySymbol> SourceEntries => GetBoundField(ref lazySourceEntries);
+    public ImmutableArray<IEntrySymbol> SourceEntries =>
+        GetBoundField(ref lazySourceEntries, BindSourceEntries);
+
+    protected sealed override void CheckReferencesCore() => _ = SourceEntries;
 
     public sealed override void Accept(SymbolVisitor visitor) =>
         visitor.VisitEntryReferencePath(this);
@@ -32,12 +35,6 @@ internal abstract class EntryReferencePathBaseSymbol : SourceDeclaredSymbol, IEn
 
     public sealed override TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
         visitor.VisitEntryReferencePath(this, argument);
-
-    protected sealed override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        lazySourceEntries = BindSourceEntries(binder, diagnostics);
-    }
 
     protected abstract ImmutableArray<IEntrySymbol> BindSourceEntries(Binder binder, BindingDiagnosticBag diagnostics);
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/EntryReferencePathSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/EntryReferencePathSymbol.cs
@@ -23,7 +23,7 @@ internal abstract class EntryReferencePathBaseSymbol : SourceDeclaredSymbol, IEn
     public sealed override SymbolKind Kind => SymbolKind.Link;
 
     public ImmutableArray<IEntrySymbol> SourceEntries =>
-        GetBoundField(ref lazySourceEntries, BindSourceEntries);
+        GetBoundField(ref lazySourceEntries, this, static (b, d, self) => self.BindSourceEntries(b, d));
 
     protected sealed override void CheckReferencesCore() => _ = SourceEntries;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceCatalogueReferenceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceCatalogueReferenceSymbol.cs
@@ -27,7 +27,10 @@ internal sealed class ForceCatalogueReferenceSymbol : SourceDeclaredSymbol, ICat
 
     public bool ImportsRootEntries => false;
 
-    public ICatalogueSymbol Catalogue => GetBoundField(ref lazyCatalogue);
+    public ICatalogueSymbol Catalogue =>
+        GetBoundField(ref lazyCatalogue, (b, d) => b.BindCatalogueSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Catalogue;
 
     public override void Accept(SymbolVisitor visitor) =>
         visitor.VisitCatalogueReference(this);
@@ -37,10 +40,4 @@ internal sealed class ForceCatalogueReferenceSymbol : SourceDeclaredSymbol, ICat
 
     public override TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
         visitor.VisitCatalogueReference(this, argument);
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        lazyCatalogue = binder.BindCatalogueSymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceCatalogueReferenceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceCatalogueReferenceSymbol.cs
@@ -28,7 +28,7 @@ internal sealed class ForceCatalogueReferenceSymbol : SourceDeclaredSymbol, ICat
     public bool ImportsRootEntries => false;
 
     public ICatalogueSymbol Catalogue =>
-        GetBoundField(ref lazyCatalogue, (b, d) => b.BindCatalogueSymbol(Declaration, d));
+        GetBoundField(ref lazyCatalogue, Declaration, static (b, d, decl) => b.BindCatalogueSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Catalogue;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceSymbol.cs
@@ -28,7 +28,7 @@ internal sealed class ForceSymbol : ContainerSymbol, IForceSymbol, INodeDeclared
     public string? EntryId => Declaration.EntryId;
 
     public override IForceEntrySymbol SourceEntry =>
-        GetBoundField(ref lazyForceEntry, (b, d) => b.BindForceEntrySymbol(Declaration, d));
+        GetBoundField(ref lazyForceEntry, Declaration, static (b, d, decl) => b.BindForceEntrySymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = SourceEntry;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ForceSymbol.cs
@@ -27,7 +27,10 @@ internal sealed class ForceSymbol : ContainerSymbol, IForceSymbol, INodeDeclared
 
     public string? EntryId => Declaration.EntryId;
 
-    public override IForceEntrySymbol SourceEntry => GetBoundField(ref lazyForceEntry);
+    public override IForceEntrySymbol SourceEntry =>
+        GetBoundField(ref lazyForceEntry, (b, d) => b.BindForceEntrySymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = SourceEntry;
 
     public ImmutableArray<ForceSymbol> Forces { get; }
 
@@ -81,12 +84,6 @@ internal sealed class ForceSymbol : ContainerSymbol, IForceSymbol, INodeDeclared
             Interlocked.CompareExchange(ref lazyEffectiveSourceEntry, result, null);
             return lazyEffectiveSourceEntry;
         }
-    }
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        lazyForceEntry = binder.BindForceEntrySymbol(Declaration, diagnostics);
     }
 
     protected override ImmutableArray<Symbol> MakeAllMembers(BindingDiagnosticBag diagnostics) =>

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ModifierEffectSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ModifierEffectSymbol.cs
@@ -54,7 +54,7 @@ internal sealed class ModifierEffectSymbol : ModifierEffectBaseSymbol, IEffectSy
         get
         {
             if (TargetKind is EffectTargetKind.Member)
-                return GetBoundField(ref lazyTargetMember, (b, d) => b.BindEffectTargetMemberSymbol(Declaration, Declaration.Field, d));
+                return GetBoundField(ref lazyTargetMember, Declaration, static (b, d, decl) => b.BindEffectTargetMemberSymbol(decl, decl.Field, d));
             return null;
         }
     }
@@ -68,7 +68,7 @@ internal sealed class ModifierEffectSymbol : ModifierEffectBaseSymbol, IEffectSy
         get
         {
             if (TargetKind is EffectTargetKind.EntryCategory)
-                return GetBoundField(ref lazyOperand, (b, d) => b.BindCategoryEntrySymbol(Declaration, Declaration.Value, d));
+                return GetBoundField(ref lazyOperand, Declaration, static (b, d, decl) => b.BindCategoryEntrySymbol(decl, decl.Value, d));
             return null;
         }
     }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ModifierEffectSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ModifierEffectSymbol.cs
@@ -49,27 +49,36 @@ internal sealed class ModifierEffectSymbol : ModifierEffectBaseSymbol, IEffectSy
 
     public override EffectTargetKind TargetKind { get; }
 
-    public override ISymbol? TargetMember => GetOptionalBoundField(ref lazyTargetMember);
+    public override ISymbol? TargetMember
+    {
+        get
+        {
+            if (TargetKind is EffectTargetKind.Member)
+                return GetBoundField(ref lazyTargetMember, (b, d) => b.BindEffectTargetMemberSymbol(Declaration, Declaration.Field, d));
+            return null;
+        }
+    }
 
     public override EffectOperation FunctionKind { get; }
 
     public override string? OperandValue => Declaration.Value;
 
-    public override ISymbol? OperandSymbol => GetOptionalBoundField(ref lazyOperand);
+    public override ISymbol? OperandSymbol
+    {
+        get
+        {
+            if (TargetKind is EffectTargetKind.EntryCategory)
+                return GetBoundField(ref lazyOperand, (b, d) => b.BindCategoryEntrySymbol(Declaration, Declaration.Value, d));
+            return null;
+        }
+    }
 
     public override ImmutableArray<ModifierEffectBaseSymbol> ChildrenWhenSatisfied =>
         ImmutableArray<ModifierEffectBaseSymbol>.Empty;
 
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
+    protected override void CheckReferencesCore()
     {
-        base.BindReferencesCore(binder, diagnostics);
-        if (TargetKind is EffectTargetKind.EntryCategory)
-        {
-            lazyOperand = binder.BindCategoryEntrySymbol(Declaration, Declaration.Value, diagnostics);
-        }
-        else if (TargetKind is EffectTargetKind.Member)
-        {
-            lazyTargetMember = binder.BindEffectTargetMemberSymbol(Declaration, Declaration.Field, diagnostics);
-        }
+        _ = TargetMember;
+        _ = OperandSymbol;
     }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ProfileSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ProfileSymbol.cs
@@ -26,7 +26,10 @@ internal sealed class ProfileSymbol : ResourceEntryBaseSymbol, IProfileSymbol, I
 
     public override ProfileNode Declaration { get; }
 
-    public override IResourceDefinitionSymbol Type => GetBoundField(ref lazyType);
+    public override IResourceDefinitionSymbol Type =>
+        GetBoundField(ref lazyType, (b, d) => b.BindProfileTypeSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Type;
 
     public override ResourceKind ResourceKind => ResourceKind.Profile;
 
@@ -40,11 +43,4 @@ internal sealed class ProfileSymbol : ResourceEntryBaseSymbol, IProfileSymbol, I
 
     ImmutableArray<ICharacteristicSymbol> IProfileSymbol.Characteristics =>
         Characteristics.Cast<CharacteristicSymbol, ICharacteristicSymbol>();
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyType = binder.BindProfileTypeSymbol(Declaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ProfileSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ProfileSymbol.cs
@@ -27,7 +27,7 @@ internal sealed class ProfileSymbol : ResourceEntryBaseSymbol, IProfileSymbol, I
     public override ProfileNode Declaration { get; }
 
     public override IResourceDefinitionSymbol Type =>
-        GetBoundField(ref lazyType, (b, d) => b.BindProfileTypeSymbol(Declaration, d));
+        GetBoundField(ref lazyType, Declaration, static (b, d, decl) => b.BindProfileTypeSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Type;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/PublicationReferenceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/PublicationReferenceSymbol.cs
@@ -46,7 +46,7 @@ internal sealed class PublicationReferenceSymbol : SourceDeclaredSymbol, IPublic
         get
         {
             if (PublicationRefDeclaration.PublicationId is not null)
-                return GetBoundField(ref lazyPublication, (b, d) => b.BindPublicationSymbol(PublicationRefDeclaration, d));
+                return GetBoundField(ref lazyPublication, PublicationRefDeclaration, static (b, d, decl) => b.BindPublicationSymbol(decl, d));
             return null;
         }
     }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/PublicationReferenceSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/PublicationReferenceSymbol.cs
@@ -41,9 +41,19 @@ internal sealed class PublicationReferenceSymbol : SourceDeclaredSymbol, IPublic
 
     public string? PublicationId => PublicationRefDeclaration.PublicationId;
 
-    public IPublicationSymbol? Publication => GetOptionalBoundField(ref lazyPublication);
+    public IPublicationSymbol? Publication
+    {
+        get
+        {
+            if (PublicationRefDeclaration.PublicationId is not null)
+                return GetBoundField(ref lazyPublication, (b, d) => b.BindPublicationSymbol(PublicationRefDeclaration, d));
+            return null;
+        }
+    }
 
     public string? Page => PublicationRefDeclaration.Page;
+
+    protected override void CheckReferencesCore() => _ = Publication;
 
     public sealed override void Accept(SymbolVisitor visitor) =>
         visitor.VisitPublicationReference(this);
@@ -53,13 +63,4 @@ internal sealed class PublicationReferenceSymbol : SourceDeclaredSymbol, IPublic
 
     public sealed override TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
         visitor.VisitPublicationReference(this, argument);
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        if (PublicationRefDeclaration.PublicationId is not null)
-        {
-            lazyPublication = binder.BindPublicationSymbol(PublicationRefDeclaration, diagnostics);
-        }
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
@@ -19,7 +19,7 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
         {
             "forces" => QueryValueKind.ForceCount,
             "selections" => QueryValueKind.SelectionCount,
-            { } id when id.StartsWith("limit::", StringComparison.Ordinal) => QueryValueKind.MemberValueLimit,
+            { } id when LimitField.IsMatch(id) => QueryValueKind.MemberValueLimit,
             { } id when !string.IsNullOrWhiteSpace(id) => QueryValueKind.MemberValue,
             _ => QueryValueKind.Unknown
         };
@@ -116,7 +116,7 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
             if (ValueKind is QueryValueKind.MemberValue)
                 return GetBoundField(ref lazyValueType, Declaration, static (b, d, decl) => b.BindCostTypeSymbol(decl, decl.Field, d));
             if (ValueKind is QueryValueKind.MemberValueLimit)
-                return GetBoundField(ref lazyValueType, Declaration, static (b, d, decl) => b.BindCostTypeSymbol(decl, decl.Field?["limit::".Length..], d));
+                return GetBoundField(ref lazyValueType, Declaration, static (b, d, decl) => b.BindCostTypeSymbol(decl, LimitField.GetCostTypeId(decl.Field), d));
             return null;
         }
     }
@@ -239,5 +239,16 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
         }
 
         public override QueryComparisonType Comparison => QueryComparisonType.None;
+    }
+
+    private static class LimitField
+    {
+        private const string Prefix = "limit::";
+
+        public static bool IsMatch(string field) =>
+            field.StartsWith(Prefix, StringComparison.Ordinal);
+
+        public static string? GetCostTypeId(string? field) =>
+            field?[Prefix.Length..];
     }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
@@ -114,9 +114,9 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
         get
         {
             if (ValueKind is QueryValueKind.MemberValue)
-                return GetBoundField(ref lazyValueType, (b, d) => b.BindCostTypeSymbol(Declaration, Declaration.Field, d));
+                return GetBoundField(ref lazyValueType, Declaration, static (b, d, decl) => b.BindCostTypeSymbol(decl, decl.Field, d));
             if (ValueKind is QueryValueKind.MemberValueLimit)
-                return GetBoundField(ref lazyValueType, (b, d) => b.BindCostTypeSymbol(Declaration, Declaration.Field?["limit::".Length..], d));
+                return GetBoundField(ref lazyValueType, Declaration, static (b, d, decl) => b.BindCostTypeSymbol(decl, decl.Field?["limit::".Length..], d));
             return null;
         }
     }
@@ -128,7 +128,7 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
         get
         {
             if (ScopeKind is QueryScopeKind.ReferencedEntry)
-                return GetBoundField(ref lazyScope, (b, d) => b.BindScopeEntrySymbol(Declaration, Declaration.Scope, d));
+                return GetBoundField(ref lazyScope, Declaration, static (b, d, decl) => b.BindScopeEntrySymbol(decl, decl.Scope, d));
             return null;
         }
     }
@@ -140,7 +140,7 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
         get
         {
             if (ValueFilterKind is QueryFilterKind.SpecifiedEntry)
-                return GetBoundField(ref lazyFilter, (b, d) => b.BindFilterEntrySymbol(Declaration, ((QueryFilteredBaseNode)Declaration).ChildId, ScopeKind, d));
+                return GetBoundField(ref lazyFilter, this, static (b, d, self) => b.BindFilterEntrySymbol(self.Declaration, ((QueryFilteredBaseNode)self.Declaration).ChildId, self.ScopeKind, d));
             return null;
         }
     }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
@@ -109,17 +109,50 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
 
     public QueryValueKind ValueKind { get; }
 
-    public ISymbol? ValueTypeSymbol => GetOptionalBoundField(ref lazyValueType);
+    public ISymbol? ValueTypeSymbol
+    {
+        get
+        {
+            if (ValueKind is QueryValueKind.MemberValue)
+                return GetBoundField(ref lazyValueType, (b, d) => b.BindCostTypeSymbol(Declaration, Declaration.Field, d));
+            if (ValueKind is QueryValueKind.MemberValueLimit)
+                return GetBoundField(ref lazyValueType, (b, d) => b.BindCostTypeSymbol(Declaration, Declaration.Field?["limit::".Length..], d));
+            return null;
+        }
+    }
 
     public QueryScopeKind ScopeKind { get; }
 
-    public ISymbol? ScopeSymbol => GetOptionalBoundField(ref lazyScope);
+    public ISymbol? ScopeSymbol
+    {
+        get
+        {
+            if (ScopeKind is QueryScopeKind.ReferencedEntry)
+                return GetBoundField(ref lazyScope, (b, d) => b.BindScopeEntrySymbol(Declaration, Declaration.Scope, d));
+            return null;
+        }
+    }
 
     public QueryFilterKind ValueFilterKind { get; }
 
-    public ISymbol? FilterSymbol => GetOptionalBoundField(ref lazyFilter);
+    public ISymbol? FilterSymbol
+    {
+        get
+        {
+            if (ValueFilterKind is QueryFilterKind.SpecifiedEntry)
+                return GetBoundField(ref lazyFilter, (b, d) => b.BindFilterEntrySymbol(Declaration, ((QueryFilteredBaseNode)Declaration).ChildId, ScopeKind, d));
+            return null;
+        }
+    }
 
     public QueryOptions Options { get; }
+
+    protected override void CheckReferencesCore()
+    {
+        _ = ValueTypeSymbol;
+        _ = ScopeSymbol;
+        _ = FilterSymbol;
+    }
 
     public static QueryBaseSymbol Create(ISymbol containingSymbol, QueryBaseNode declaration, DiagnosticBag diagnostics)
     {
@@ -140,28 +173,6 @@ internal abstract class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
 
     public sealed override TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
         visitor.VisitQuery(this, argument);
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        if (ValueKind is QueryValueKind.MemberValue)
-        {
-            lazyValueType = binder.BindCostTypeSymbol(Declaration, Declaration.Field, diagnostics);
-        }
-        else if (ValueKind is QueryValueKind.MemberValueLimit)
-        {
-            // limit:: prefix (e.g. limit::abc-123) is used to describe roster cost limit
-            lazyValueType = binder.BindCostTypeSymbol(Declaration, Declaration.Field?["limit::".Length..], diagnostics);
-        }
-        if (ScopeKind is QueryScopeKind.ReferencedEntry)
-        {
-            lazyScope = binder.BindScopeEntrySymbol(Declaration, Declaration.Scope, diagnostics);
-        }
-        if (ValueFilterKind is QueryFilterKind.SpecifiedEntry)
-        {
-            lazyFilter = binder.BindFilterEntrySymbol(Declaration, ((QueryFilteredBaseNode)Declaration).ChildId, ScopeKind, diagnostics);
-        }
-    }
 
     internal sealed class ConditionQuerySymbol : QueryBaseSymbol
     {

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ResourceLinkSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ResourceLinkSymbol.cs
@@ -33,12 +33,8 @@ internal sealed class ResourceLinkSymbol : ResourceEntryBaseSymbol, IResourceEnt
 
     public override ResourceKind ResourceKind { get; }
 
-    public override IResourceEntrySymbol ReferencedEntry => GetBoundField(ref lazyReferencedEntry);
+    public override IResourceEntrySymbol ReferencedEntry =>
+        GetBoundField(ref lazyReferencedEntry, (b, d) => b.BindSharedResourceEntrySymbol(Declaration, d));
 
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyReferencedEntry = binder.BindSharedResourceEntrySymbol(Declaration, diagnostics);
-    }
+    protected override void CheckReferencesCore() => _ = ReferencedEntry;
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ResourceLinkSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ResourceLinkSymbol.cs
@@ -34,7 +34,7 @@ internal sealed class ResourceLinkSymbol : ResourceEntryBaseSymbol, IResourceEnt
     public override ResourceKind ResourceKind { get; }
 
     public override IResourceEntrySymbol ReferencedEntry =>
-        GetBoundField(ref lazyReferencedEntry, (b, d) => b.BindSharedResourceEntrySymbol(Declaration, d));
+        GetBoundField(ref lazyReferencedEntry, Declaration, static (b, d, decl) => b.BindSharedResourceEntrySymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = ReferencedEntry;
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterCostSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterCostSymbol.cs
@@ -43,7 +43,7 @@ internal sealed class RosterCostSymbol : SourceDeclaredSymbol, IRosterCostSymbol
     }
 
     public IResourceDefinitionSymbol CostType =>
-        GetBoundField(ref lazyType, (b, d) => b.BindCostTypeSymbol(CostDeclaration, d));
+        GetBoundField(ref lazyType, CostDeclaration, static (b, d, decl) => b.BindCostTypeSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = CostType;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterCostSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterCostSymbol.cs
@@ -42,7 +42,10 @@ internal sealed class RosterCostSymbol : SourceDeclaredSymbol, IRosterCostSymbol
         }
     }
 
-    public IResourceDefinitionSymbol CostType => GetBoundField(ref lazyType);
+    public IResourceDefinitionSymbol CostType =>
+        GetBoundField(ref lazyType, (b, d) => b.BindCostTypeSymbol(CostDeclaration, d));
+
+    protected override void CheckReferencesCore() => _ = CostType;
 
     public override void Accept(SymbolVisitor visitor) =>
         visitor.VisitRosterCost(this);
@@ -52,10 +55,4 @@ internal sealed class RosterCostSymbol : SourceDeclaredSymbol, IRosterCostSymbol
 
     public override TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
         visitor.VisitRosterCost(this, argument);
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        lazyType = binder.BindCostTypeSymbol(CostDeclaration, diagnostics);
-    }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterProfileSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterProfileSymbol.cs
@@ -16,7 +16,10 @@ internal sealed class RosterProfileSymbol : RosterResourceBaseSymbol, IRosterPro
 
     public override ResourceKind ResourceKind => ResourceKind.Profile;
 
-    public IResourceDefinitionSymbol Type => GetBoundField(ref lazyType);
+    public IResourceDefinitionSymbol Type =>
+        GetBoundField(ref lazyType, (b, d) => b.BindProfileTypeSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Type;
 
     public ImmutableArray<CharacteristicSymbol> Characteristics { get; }
 
@@ -24,12 +27,6 @@ internal sealed class RosterProfileSymbol : RosterResourceBaseSymbol, IRosterPro
 
     ImmutableArray<ICharacteristicSymbol> IRosterProfileSymbol.Characteristics =>
         Characteristics.Cast<CharacteristicSymbol, ICharacteristicSymbol>();
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        lazyType = binder.BindProfileTypeSymbol(Declaration, diagnostics);
-    }
 
     protected override ImmutableArray<Symbol> MakeAllMembers(BindingDiagnosticBag diagnostics) =>
         base.MakeAllMembers(diagnostics)

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterProfileSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterProfileSymbol.cs
@@ -17,7 +17,7 @@ internal sealed class RosterProfileSymbol : RosterResourceBaseSymbol, IRosterPro
     public override ResourceKind ResourceKind => ResourceKind.Profile;
 
     public IResourceDefinitionSymbol Type =>
-        GetBoundField(ref lazyType, (b, d) => b.BindProfileTypeSymbol(Declaration, d));
+        GetBoundField(ref lazyType, Declaration, static (b, d, decl) => b.BindProfileTypeSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Type;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterSymbol.cs
@@ -47,7 +47,7 @@ internal sealed class RosterSymbol : SourceDeclaredSymbol, IRosterSymbol, INodeD
     public string? CustomNotes => Declaration.CustomNotes;
 
     public ICatalogueSymbol Gamesystem =>
-        GetBoundField(ref lazyGamesystem, (b, d) => b.BindGamesystemSymbol(Declaration, d));
+        GetBoundField(ref lazyGamesystem, Declaration, static (b, d, decl) => b.BindGamesystemSymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = Gamesystem;
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/RosterSymbol.cs
@@ -46,7 +46,10 @@ internal sealed class RosterSymbol : SourceDeclaredSymbol, IRosterSymbol, INodeD
 
     public string? CustomNotes => Declaration.CustomNotes;
 
-    public ICatalogueSymbol Gamesystem => GetBoundField(ref lazyGamesystem);
+    public ICatalogueSymbol Gamesystem =>
+        GetBoundField(ref lazyGamesystem, (b, d) => b.BindGamesystemSymbol(Declaration, d));
+
+    protected override void CheckReferencesCore() => _ = Gamesystem;
 
     /// <summary>
     /// Gets or lazily creates the effective entry cache for this roster.
@@ -89,12 +92,6 @@ internal sealed class RosterSymbol : SourceDeclaredSymbol, IRosterSymbol, INodeD
 
     public override TResult Accept<TArgument, TResult>(SymbolVisitor<TArgument, TResult> visitor, TArgument argument) =>
         visitor.VisitRoster(this, argument);
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-        lazyGamesystem = binder.BindGamesystemSymbol(Declaration, diagnostics);
-    }
 
     protected override void ComputeEffectiveEntries()
     {
@@ -162,19 +159,19 @@ internal sealed class RosterSymbol : SourceDeclaredSymbol, IRosterSymbol, INodeD
         }
     }
 
-    protected override void EvaluateConstraints()
+    protected override void CheckConstraints()
     {
-        if (state.HasComplete(CompletionPart.ConstraintsCompleted))
+        if (state.HasComplete(CompletionPart.CheckConstraintsCompleted))
             return;
-        if (state.NotePartComplete(CompletionPart.StartConstraints))
+        if (state.NotePartComplete(CompletionPart.StartCheckConstraints))
         {
             var diagnostics = DiagnosticBag.GetInstance();
             ConstraintEvaluator.Evaluate(this, (WhamCompilation)DeclaringCompilation, diagnostics);
             AddConstraintDiagnostics(diagnostics);
             diagnostics.Free();
-            state.NotePartComplete(CompletionPart.FinishConstraints);
+            state.NotePartComplete(CompletionPart.FinishCheckConstraints);
         }
-        state.SpinWaitComplete(CompletionPart.ConstraintsCompleted, default);
+        state.SpinWaitComplete(CompletionPart.CheckConstraintsCompleted, default);
     }
 
     protected override ImmutableArray<Symbol> MakeAllMembers(BindingDiagnosticBag diagnostics) =>

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryGroupSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryGroupSymbol.cs
@@ -24,7 +24,7 @@ internal sealed class SelectionEntryGroupSymbol : SelectionEntryBaseSymbol, ISel
         get
         {
             if (Declaration.DefaultSelectionEntryId is not null)
-                return GetBoundField(ref lazyDefaultEntry, (b, d) => b.BindSelectionEntryGroupDefaultEntrySymbol(Declaration, this, d));
+                return GetBoundField(ref lazyDefaultEntry, this, static (b, d, self) => b.BindSelectionEntryGroupDefaultEntrySymbol(self.Declaration, self, d));
             return null;
         }
     }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryGroupSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryGroupSymbol.cs
@@ -19,15 +19,15 @@ internal sealed class SelectionEntryGroupSymbol : SelectionEntryBaseSymbol, ISel
 
     public override ContainerKind ContainerKind => ContainerKind.SelectionGroup;
 
-    public ISelectionEntryContainerSymbol? DefaultSelectionEntry => GetOptionalBoundField(ref lazyDefaultEntry);
-
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
+    public ISelectionEntryContainerSymbol? DefaultSelectionEntry
     {
-        base.BindReferencesCore(binder, diagnostics);
-
-        if (Declaration.DefaultSelectionEntryId is not null)
+        get
         {
-            lazyDefaultEntry = binder.BindSelectionEntryGroupDefaultEntrySymbol(Declaration, this, diagnostics);
+            if (Declaration.DefaultSelectionEntryId is not null)
+                return GetBoundField(ref lazyDefaultEntry, (b, d) => b.BindSelectionEntryGroupDefaultEntrySymbol(Declaration, this, d));
+            return null;
         }
     }
+
+    protected override void CheckReferencesCore() => _ = DefaultSelectionEntry;
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryLinkSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryLinkSymbol.cs
@@ -32,12 +32,8 @@ internal sealed class SelectionEntryLinkSymbol : SelectionEntryBaseSymbol, INode
 
     public override ContainerKind ContainerKind { get; }
 
-    public override ISelectionEntryContainerSymbol ReferencedEntry => GetBoundField(ref lazyReference);
+    public override ISelectionEntryContainerSymbol ReferencedEntry =>
+        GetBoundField(ref lazyReference, (b, d) => b.BindSelectionEntrySymbol(Declaration, d));
 
-    protected override void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-        base.BindReferencesCore(binder, diagnostics);
-
-        lazyReference = binder.BindSelectionEntrySymbol(Declaration, diagnostics);
-    }
+    protected override void CheckReferencesCore() => _ = ReferencedEntry;
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryLinkSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryLinkSymbol.cs
@@ -33,7 +33,7 @@ internal sealed class SelectionEntryLinkSymbol : SelectionEntryBaseSymbol, INode
     public override ContainerKind ContainerKind { get; }
 
     public override ISelectionEntryContainerSymbol ReferencedEntry =>
-        GetBoundField(ref lazyReference, (b, d) => b.BindSelectionEntrySymbol(Declaration, d));
+        GetBoundField(ref lazyReference, Declaration, static (b, d, decl) => b.BindSelectionEntrySymbol(decl, d));
 
     protected override void CheckReferencesCore() => _ = ReferencedEntry;
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SourceDeclaredSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SourceDeclaredSymbol.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using WarHub.ArmouryModel.Source;
 
 namespace WarHub.ArmouryModel.Concrete;
@@ -165,30 +166,43 @@ internal abstract class SourceDeclaredSymbol : Symbol, INodeDeclaredSymbol<Sourc
     /// <summary>
     /// Self-completing bound field accessor. Each field binds itself independently
     /// on first access via <see cref="Interlocked.CompareExchange{T}"/>.
+    /// Uses a state parameter so that callers can use <c>static</c> lambdas (zero-allocation).
     /// </summary>
-    protected T GetBoundField<T>(ref T? field, Func<Binder, BindingDiagnosticBag, T> bind) where T : class
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected T GetBoundField<T, TState>(ref T? field, TState state, Func<Binder, BindingDiagnosticBag, TState, T> bind) where T : class
     {
-        if (field is not null) return field;
-        var binder = DeclaringCompilation.GetBinder(Declaration, ContainingSymbol);
-        var diagnostics = BindingDiagnosticBag.GetInstance();
-        var result = bind(binder, diagnostics);
-        if (Interlocked.CompareExchange(ref field, result, null) is null)
-        {
-            AddDeclarationDiagnostics(diagnostics);
-        }
-        diagnostics.Free();
-        return field;
+        return field ?? BindField(ref field, state, bind);
     }
 
     /// <summary>
     /// Self-completing bound field accessor for <see cref="ImmutableArray{T}"/> fields.
     /// </summary>
-    protected ImmutableArray<T> GetBoundField<T>(ref ImmutableArray<T> field, Func<Binder, BindingDiagnosticBag, ImmutableArray<T>> bind)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected ImmutableArray<T> GetBoundField<T, TState>(ref ImmutableArray<T> field, TState state, Func<Binder, BindingDiagnosticBag, TState, ImmutableArray<T>> bind)
     {
-        if (!field.IsDefault) return field;
+        return !field.IsDefault ? field : BindField(ref field, state, bind);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private T BindField<T, TState>(ref T? field, TState state, Func<Binder, BindingDiagnosticBag, TState, T> bind) where T : class
+    {
         var binder = DeclaringCompilation.GetBinder(Declaration, ContainingSymbol);
         var diagnostics = BindingDiagnosticBag.GetInstance();
-        var result = bind(binder, diagnostics);
+        var result = bind(binder, diagnostics, state);
+        if (Interlocked.CompareExchange(ref field, result, null) is null)
+        {
+            AddDeclarationDiagnostics(diagnostics);
+        }
+        diagnostics.Free();
+        return field!;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private ImmutableArray<T> BindField<T, TState>(ref ImmutableArray<T> field, TState state, Func<Binder, BindingDiagnosticBag, TState, ImmutableArray<T>> bind)
+    {
+        var binder = DeclaringCompilation.GetBinder(Declaration, ContainingSymbol);
+        var diagnostics = BindingDiagnosticBag.GetInstance();
+        var result = bind(binder, diagnostics, state);
         if (ImmutableInterlocked.InterlockedCompareExchange(ref field, result, default).IsDefault)
         {
             AddDeclarationDiagnostics(diagnostics);

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SourceDeclaredSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SourceDeclaredSymbol.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using WarHub.ArmouryModel.Source;
 
 namespace WarHub.ArmouryModel.Concrete;
@@ -8,13 +7,6 @@ internal abstract class SourceDeclaredSymbol : Symbol, INodeDeclaredSymbol<Sourc
 {
     protected SymbolCompletionState state;
     private ImmutableArray<Symbol> lazyMembers;
-
-    /// <summary>
-    /// Thread-local set of symbols currently in <see cref="BindReferences"/>.
-    /// Used to detect reentrancy when <see cref="CompilationOptions.DetectBindingReentrancy"/> is enabled.
-    /// </summary>
-    [ThreadStatic]
-    private static HashSet<SourceDeclaredSymbol>? t_bindingSymbols;
 
     protected SourceDeclaredSymbol(
         ISymbol? containingSymbol,
@@ -60,10 +52,6 @@ internal abstract class SourceDeclaredSymbol : Symbol, INodeDeclaredSymbol<Sourc
             {
                 case CompletionPart.None:
                     return;
-                case CompletionPart.StartBindingReferences:
-                case CompletionPart.FinishBindingReferences:
-                    BindReferences();
-                    break;
                 case CompletionPart.Members:
                     GetMembersCore();
                     break;
@@ -82,9 +70,13 @@ internal abstract class SourceDeclaredSymbol : Symbol, INodeDeclaredSymbol<Sourc
                 case CompletionPart.FinishEffectiveEntries:
                     ComputeEffectiveEntries();
                     break;
-                case CompletionPart.StartConstraints:
-                case CompletionPart.FinishConstraints:
-                    EvaluateConstraints();
+                case CompletionPart.StartCheckReferences:
+                case CompletionPart.FinishCheckReferences:
+                    CheckReferences();
+                    break;
+                case CompletionPart.StartCheckConstraints:
+                case CompletionPart.FinishCheckConstraints:
+                    CheckConstraints();
                     break;
                 default:
                     // This assert will trigger if we forgot to handle any of the completion parts
@@ -129,63 +121,6 @@ internal abstract class SourceDeclaredSymbol : Symbol, INodeDeclaredSymbol<Sourc
     protected virtual ImmutableArray<Symbol> MakeAllMembers(BindingDiagnosticBag diagnostics) =>
         ImmutableArray<Symbol>.Empty;
 
-    protected void BindReferences()
-    {
-        if (state.HasComplete(CompletionPart.ReferencesCompleted))
-        {
-            return;
-        }
-        if (DeclaringCompilation.Options.DetectBindingReentrancy)
-        {
-            BindReferencesWithReentrancyDetection();
-            return;
-        }
-        BindReferencesCore();
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void BindReferencesWithReentrancyDetection()
-    {
-        var binding = t_bindingSymbols ??= [];
-        if (!binding.Add(this))
-        {
-            ThrowReentrancyDetected(binding);
-        }
-        try
-        {
-            BindReferencesCore();
-        }
-        finally
-        {
-            binding.Remove(this);
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void ThrowReentrancyDetected(HashSet<SourceDeclaredSymbol> binding)
-    {
-        throw new InvalidOperationException(
-            $"Binding reentrancy detected on symbol '{Name}' ({GetType().Name}, Id='{Id}'). " +
-            $"This symbol is already being bound on this thread. " +
-            $"Currently binding: [{string.Join(", ", binding.Select(s => $"{s.GetType().Name}('{s.Name}')"))}]");
-    }
-
-    private void BindReferencesCore()
-    {
-        if (state.NotePartComplete(CompletionPart.StartBindingReferences))
-        {
-            var diagnostics = BindingDiagnosticBag.GetInstance();
-            BindReferencesCore(DeclaringCompilation.GetBinder(Declaration, ContainingSymbol), diagnostics);
-            AddDeclarationDiagnostics(diagnostics);
-            state.NotePartComplete(CompletionPart.FinishBindingReferences);
-        }
-        state.SpinWaitComplete(CompletionPart.ReferencesCompleted, default);
-    }
-
-    protected virtual void BindReferencesCore(Binder binder, BindingDiagnosticBag diagnostics)
-    {
-    }
-
     /// <summary>
     /// Computes effective entries (name/hidden/costs/constraints after modifier application).
     /// Only meaningful for RosterSymbol; base auto-completes.
@@ -196,39 +131,69 @@ internal abstract class SourceDeclaredSymbol : Symbol, INodeDeclaredSymbol<Sourc
     }
 
     /// <summary>
+    /// Inspects self-completed bound fields and reports diagnostics for errors.
+    /// The base implementation calls <see cref="CheckReferencesCore"/> wrapped in the
+    /// Start/Finish completion pattern.
+    /// </summary>
+    protected void CheckReferences()
+    {
+        if (state.NotePartComplete(CompletionPart.StartCheckReferences))
+        {
+            CheckReferencesCore();
+            state.NotePartComplete(CompletionPart.FinishCheckReferences);
+        }
+        state.SpinWaitComplete(CompletionPart.CheckReferencesCompleted, default);
+    }
+
+    /// <summary>
+    /// Override to access all lazy bound fields, ensuring their binding diagnostics
+    /// are reported before <c>GetDiagnostics()</c> returns.
+    /// </summary>
+    protected virtual void CheckReferencesCore()
+    {
+    }
+
+    /// <summary>
     /// Evaluates constraints (min/max selection count, cost limits, etc.).
     /// Only meaningful for RosterSymbol; base auto-completes.
     /// </summary>
-    protected virtual void EvaluateConstraints()
+    protected virtual void CheckConstraints()
     {
-        state.NotePartComplete(CompletionPart.ConstraintsCompleted);
+        state.NotePartComplete(CompletionPart.CheckConstraintsCompleted);
     }
 
-    protected T GetBoundField<T>(ref T? field) where T : notnull
+    /// <summary>
+    /// Self-completing bound field accessor. Each field binds itself independently
+    /// on first access via <see cref="Interlocked.CompareExchange{T}"/>.
+    /// </summary>
+    protected T GetBoundField<T>(ref T? field, Func<Binder, BindingDiagnosticBag, T> bind) where T : class
     {
-        if (!state.HasComplete(CompletionPart.ReferencesCompleted))
+        if (field is not null) return field;
+        var binder = DeclaringCompilation.GetBinder(Declaration, ContainingSymbol);
+        var diagnostics = BindingDiagnosticBag.GetInstance();
+        var result = bind(binder, diagnostics);
+        if (Interlocked.CompareExchange(ref field, result, null) is null)
         {
-            BindReferences();
+            AddDeclarationDiagnostics(diagnostics);
         }
-        return field ?? throw new InvalidOperationException("Bound field was null after binding.");
+        diagnostics.Free();
+        return field;
     }
 
-    protected ImmutableArray<T> GetBoundField<T>(ref ImmutableArray<T> field)
+    /// <summary>
+    /// Self-completing bound field accessor for <see cref="ImmutableArray{T}"/> fields.
+    /// </summary>
+    protected ImmutableArray<T> GetBoundField<T>(ref ImmutableArray<T> field, Func<Binder, BindingDiagnosticBag, ImmutableArray<T>> bind)
     {
-        if (!state.HasComplete(CompletionPart.ReferencesCompleted))
+        if (!field.IsDefault) return field;
+        var binder = DeclaringCompilation.GetBinder(Declaration, ContainingSymbol);
+        var diagnostics = BindingDiagnosticBag.GetInstance();
+        var result = bind(binder, diagnostics);
+        if (ImmutableInterlocked.InterlockedCompareExchange(ref field, result, default).IsDefault)
         {
-            BindReferences();
+            AddDeclarationDiagnostics(diagnostics);
         }
-        return !field.IsDefault ? field : throw new InvalidOperationException("Bound field still had default value after binding.");
-    }
-
-
-    protected T? GetOptionalBoundField<T>(ref T? field)
-    {
-        if (!state.HasComplete(CompletionPart.ReferencesCompleted))
-        {
-            BindReferences();
-        }
+        diagnostics.Free();
         return field;
     }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Utilities/CompletionPart.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Utilities/CompletionPart.cs
@@ -6,36 +6,40 @@ namespace WarHub.ArmouryModel.Concrete;
 /// until all of these types are accounted for.
 /// From: https://sourceroslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/CompletionPart.cs
 /// </summary>
+/// <remarks>
+/// Bound reference fields are self-completing (each property binds itself on first access
+/// via <c>Interlocked.CompareExchange</c>) and do not require a dedicated completion phase.
+/// </remarks>
 [Flags]
 internal enum CompletionPart
 {
     None = 0,
 
-    // Phase 1: Binding
-    StartBindingReferences = 1 << 0,
-    FinishBindingReferences = 1 << 1,
-    ReferencesCompleted = StartBindingReferences | FinishBindingReferences,
+    // Phase 1: Members
+    Members = 1 << 0,
+    MembersCompleted = 1 << 1,
 
-    // Phase 2: Members
-    Members = 1 << 2,
-    MembersCompleted = 1 << 3,
-
-    // Phase 3: Effective entries (computed by RosterSymbol, auto-completed by others)
-    StartEffectiveEntries = 1 << 4,
-    FinishEffectiveEntries = 1 << 5,
+    // Phase 2: Effective entries (computed by RosterSymbol, auto-completed by others)
+    StartEffectiveEntries = 1 << 2,
+    FinishEffectiveEntries = 1 << 3,
     EffectiveEntriesCompleted = StartEffectiveEntries | FinishEffectiveEntries,
 
-    // Phase 4: Constraints (evaluated by RosterSymbol, auto-completed by others)
-    StartConstraints = 1 << 6,
-    FinishConstraints = 1 << 7,
-    ConstraintsCompleted = StartConstraints | FinishConstraints,
+    // Phase 3: Check references (inspect self-completed bound fields for errors)
+    StartCheckReferences = 1 << 4,
+    FinishCheckReferences = 1 << 5,
+    CheckReferencesCompleted = StartCheckReferences | FinishCheckReferences,
+
+    // Phase 4: Check constraints (evaluated by RosterSymbol, auto-completed by others)
+    StartCheckConstraints = 1 << 6,
+    FinishCheckConstraints = 1 << 7,
+    CheckConstraintsCompleted = StartCheckConstraints | FinishCheckConstraints,
 
 #pragma warning disable CA1069 // The enum member has the same constant value as member
     All = (1 << 8) - 1,
 
     // source symbol
-    SourceDeclaredSymbolAll = ReferencesCompleted | Members | MembersCompleted
-        | EffectiveEntriesCompleted | ConstraintsCompleted,
+    SourceDeclaredSymbolAll = Members | MembersCompleted
+        | EffectiveEntriesCompleted | CheckReferencesCompleted | CheckConstraintsCompleted,
 
     // roster symbol (same as SourceDeclaredSymbolAll for now, but explicit)
     RosterSymbolAll = SourceDeclaredSymbolAll,

--- a/src/WarHub.ArmouryModel.Extensions/Compilation/CompilationOptions.cs
+++ b/src/WarHub.ArmouryModel.Extensions/Compilation/CompilationOptions.cs
@@ -8,15 +8,4 @@ public abstract record CompilationOptions
     /// Defaults to <see langword="true"/>.
     /// </summary>
     public bool BindEntryReferencesToNestedEntries { get; init; } = true;
-
-    /// <summary>
-    /// When <see langword="true"/>, enables same-thread reentrancy detection during symbol binding.
-    /// If a symbol's binding triggers re-entrance to its own <c>BindReferences</c>,
-    /// an <see cref="InvalidOperationException"/> is thrown instead of spinning forever.
-    /// <para>
-    /// This is a diagnostic/testing aid. Enable in tests to catch binding cycles early.
-    /// Defaults to <see langword="false"/> (production behavior: SpinWait as in Roslyn).
-    /// </para>
-    /// </summary>
-    public bool DetectBindingReentrancy { get; init; }
 }

--- a/tests/WarHub.ArmouryModel.Concrete.Extensions.Tests/ReentrancyDetectionTests.cs
+++ b/tests/WarHub.ArmouryModel.Concrete.Extensions.Tests/ReentrancyDetectionTests.cs
@@ -8,19 +8,17 @@ namespace WarHub.ArmouryModel;
 public class ReentrancyDetectionTests
 {
     [Fact]
-    public void DetectBindingReentrancy_enabled_normal_compilation_succeeds()
+    public void Compilation_with_entry_links_succeeds()
     {
-        // A normal compilation should work fine even with reentrancy detection on.
+        // Self-completing properties should handle entry links without reentrancy issues.
         var gst = NodeFactory.Gamesystem("gst");
         var cat = NodeFactory.Catalogue(gst, "cat")
             .AddSharedSelectionEntries(
                 NodeFactory.SelectionEntry("entry").Tee(out var entry))
             .AddEntryLinks(
                 NodeFactory.EntryLink(entry));
-        var options = new WhamCompilationOptions { DetectBindingReentrancy = true };
         var compilation = WhamCompilation.Create(
-            [SourceTree.CreateForRoot(gst), SourceTree.CreateForRoot(cat)],
-            options);
+            [SourceTree.CreateForRoot(gst), SourceTree.CreateForRoot(cat)]);
 
         var diagnostics = compilation.GetDiagnostics();
 
@@ -29,12 +27,5 @@ public class ReentrancyDetectionTests
         catalogue.RootContainerEntries.Should().ContainSingle()
             .Which.ReferencedEntry
             .Should().Be(catalogue.SharedSelectionEntryContainers.Single());
-    }
-
-    [Fact]
-    public void DetectBindingReentrancy_default_is_false()
-    {
-        var options = new WhamCompilationOptions();
-        options.DetectBindingReentrancy.Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary

Refactor from monolithic `BindReferencesCore` to Roslyn-style **self-completing properties**. Each lazy bound field initializes itself independently on first access via `Interlocked.CompareExchange`, eliminating the `BindReferences` completion phase entirely.

## Key Changes

- **Remove `BindReferences` phase** from `CompletionPart` enum and `ForceComplete`
- **New `GetBoundField<T>(ref field, Func<Binder, Diag, T>)`** — self-completing, thread-safe
- **Migrate all 19 symbol classes** — replace `BindReferencesCore` overrides with inline bind lambdas in property getters
- **Add `CheckReferences` phase** — forces access to all bound fields during `ForceComplete` to ensure diagnostics are reported
- **Rename `Constraints` → `CheckConstraints`** for consistency with the Get/Check phase model
- **Remove `DetectBindingReentrancy`** option — no longer needed since there's no monolithic binding phase

## New Completion Pipeline

```
OLD:  BindReferences → Members → EffectiveEntries → Constraints
NEW:  Members → MembersCompleted → EffectiveEntries → CheckReferences → CheckConstraints
      (Bound fields self-complete via Interlocked.CompareExchange on first access)
```

## Benefits

- Properties work at any time, from any context, without phase dependencies
- No reentrancy risk from accessing lazy properties during binding
- Each field binds independently (no monolithic all-or-nothing)
- Foundation for future deferred-diagnostics via `CheckReferences` inspection

## Test Results

All **720 tests pass** including all **304 conformance specs**.

## Follow-up opportunities

- New Binder overloads that return error symbols without diagnostic bag (defer diagnostics to CheckReferences)
- Simplify ModifierEvaluator to use ISymbol properties directly (remove Declaration workarounds)
- Add targeted tests for concurrent property access and access without ForceComplete
