### PR TITLE
feat: update battlescribe-spec and implement collective semantics

### DIFF
--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Binders/Binder.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Binders/Binder.cs
@@ -160,9 +160,9 @@ internal class Binder
     internal ISymbol BindFilterEntrySymbol(SourceNode node, string? symbolId, QueryScopeKind scopeKind, BindingDiagnosticBag diagnostics)
         => scopeKind switch
         {
-            QueryScopeKind.PrimaryCatalogue => BindCatalogueSymbol(node, symbolId, diagnostics),
-            // PrimaryCategory scope defines the scope (look in selections sharing the same primary category),
-            // but the childId/filter still references any container entry (typically a selection entry).
+            // primary-catalogue scope defines WHERE to count (in the force's primary catalogue),
+            // but the childId/filter still references a selection entry, same as other scopes.
+            // All scopes except ReferencedEntry use container entry lookup for the filter.
             _ => BindSimple<IContainerEntrySymbol, ErrorSymbols.ErrorContainerEntrySymbol>(node, diagnostics, symbolId, LookupOptions.ContainerEntryOnly)
         };
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Binders/Binder.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Binders/Binder.cs
@@ -157,14 +157,8 @@ internal class Binder
         return initialResult;
     }
 
-    internal ISymbol BindFilterEntrySymbol(SourceNode node, string? symbolId, QueryScopeKind scopeKind, BindingDiagnosticBag diagnostics)
-        => scopeKind switch
-        {
-            // primary-catalogue scope defines WHERE to count (in the force's primary catalogue),
-            // but the childId/filter still references a selection entry, same as other scopes.
-            // All scopes except ReferencedEntry use container entry lookup for the filter.
-            _ => BindSimple<IContainerEntrySymbol, ErrorSymbols.ErrorContainerEntrySymbol>(node, diagnostics, symbolId, LookupOptions.ContainerEntryOnly)
-        };
+    internal ISymbol BindFilterEntrySymbol(SourceNode node, string? symbolId, BindingDiagnosticBag diagnostics)
+        => BindSimple<IContainerEntrySymbol, ErrorSymbols.ErrorContainerEntrySymbol>(node, diagnostics, symbolId, LookupOptions.ContainerEntryOnly);
 
     internal ISymbol BindScopeEntrySymbol(SourceNode node, string? symbolId, BindingDiagnosticBag diagnostics) =>
         BindSimple<IContainerEntrySymbol, ErrorSymbols.ErrorContainerEntrySymbol>(node, diagnostics, symbolId, LookupOptions.ContainerEntryOnly);

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ErrorSymbols.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ErrorSymbols.cs
@@ -164,6 +164,8 @@ internal static class ErrorSymbols
 
     internal record ErrorSelectionEntryContainerSymbol : ErrorContainerEntrySymbol, ISelectionEntryContainerSymbol
     {
+        bool ISelectionEntryContainerSymbol.IsCollective => false;
+
         ICategoryEntrySymbol? ISelectionEntryContainerSymbol.PrimaryCategory => null;
 
         ImmutableArray<ICategoryEntrySymbol> ISelectionEntryContainerSymbol.Categories =>

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
@@ -18,8 +18,8 @@ internal static class SelectionOrdering
     /// <summary>
     /// Returns force's selections sorted in BattleScribe canonical order:
     /// primary by category order (as declared in the force's category list),
-    /// secondary by original entry name (natural sort),
-    /// tertiary by effective (modifier-applied) name (natural sort).
+    /// secondary by effective (modifier-applied) name (natural sort),
+    /// tertiary by original entry name (natural sort).
     /// </summary>
     internal static ImmutableArray<ISelectionSymbol> GetSortedSelections(IForceSymbol force)
     {
@@ -41,26 +41,26 @@ internal static class SelectionOrdering
                 int bOrder = bCatId is not null && categoryOrder.TryGetValue(bCatId, out var bo) ? bo : -1;
                 var cmp = aOrder.CompareTo(bOrder);
                 if (cmp != 0) return cmp;
-                // Sort by original (pre-modifier) entry name, with effective name as tiebreaker
-                cmp = NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
+                // Sort by effective (modifier-applied) name, with original entry name as tiebreaker
+                cmp = NaturalSort.Compare(a.EffectiveSourceEntry.Name, b.EffectiveSourceEntry.Name);
                 if (cmp != 0) return cmp;
-                return NaturalSort.Compare(a.EffectiveSourceEntry.Name, b.EffectiveSourceEntry.Name);
+                return NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
             });
     }
 
     /// <summary>
     /// Returns child selections sorted by name in BattleScribe canonical order:
-    /// primary by original entry name (natural sort),
-    /// secondary by effective name (natural sort).
+    /// primary by effective (modifier-applied) name (natural sort),
+    /// secondary by original entry name (natural sort).
     /// </summary>
     internal static ImmutableArray<ISelectionSymbol> GetSortedChildSelections(ISelectionSymbol parent)
     {
         return parent.Selections
             .Sort((a, b) =>
             {
-                var cmp = NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
+                var cmp = NaturalSort.Compare(a.EffectiveSourceEntry.Name, b.EffectiveSourceEntry.Name);
                 if (cmp != 0) return cmp;
-                return NaturalSort.Compare(a.EffectiveSourceEntry.Name, b.EffectiveSourceEntry.Name);
+                return NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
             });
     }
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
@@ -23,7 +23,6 @@ internal static class SelectionOrdering
     /// </summary>
     internal static ImmutableArray<ISelectionSymbol> GetSortedSelections(IForceSymbol force)
     {
-        // Build category order map from force's category list
         var categoryOrder = new Dictionary<string, int>(StringComparer.Ordinal);
         for (int i = 0; i < force.Categories.Length; i++)
         {
@@ -32,20 +31,7 @@ internal static class SelectionOrdering
                 categoryOrder[catEntryId] = i;
         }
 
-        return force.Selections
-            .Sort((a, b) =>
-            {
-                var aCatId = a.PrimaryCategory?.SourceEntry?.Id;
-                var bCatId = b.PrimaryCategory?.SourceEntry?.Id;
-                int aOrder = aCatId is not null && categoryOrder.TryGetValue(aCatId, out var ao) ? ao : -1;
-                int bOrder = bCatId is not null && categoryOrder.TryGetValue(bCatId, out var bo) ? bo : -1;
-                var cmp = aOrder.CompareTo(bOrder);
-                if (cmp != 0) return cmp;
-                // Sort by effective (modifier-applied) name, with original entry name as tiebreaker
-                cmp = NaturalSort.Compare(a.EffectiveSourceEntry.Name, b.EffectiveSourceEntry.Name);
-                if (cmp != 0) return cmp;
-                return NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
-            });
+        return force.Selections.Sort(new ForceSelectionComparer(categoryOrder));
     }
 
     /// <summary>
@@ -55,13 +41,7 @@ internal static class SelectionOrdering
     /// </summary>
     internal static ImmutableArray<ISelectionSymbol> GetSortedChildSelections(ISelectionSymbol parent)
     {
-        return parent.Selections
-            .Sort((a, b) =>
-            {
-                var cmp = NaturalSort.Compare(a.EffectiveSourceEntry.Name, b.EffectiveSourceEntry.Name);
-                if (cmp != 0) return cmp;
-                return NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
-            });
+        return parent.Selections.Sort(SelectionNameComparer.Instance);
     }
 
     /// <summary>
@@ -69,6 +49,66 @@ internal static class SelectionOrdering
     /// </summary>
     internal static ImmutableArray<IForceSymbol> GetSortedForces(IForceContainerSymbol container)
     {
-        return container.Forces.Sort((a, b) => NaturalSort.Compare(a.Name, b.Name));
+        return container.Forces.Sort(ForceNameComparer.Instance);
+    }
+
+    /// <summary>
+    /// Compares selections by effective name (natural sort), with original entry name as tiebreaker
+    /// only when modifiers have changed at least one name.
+    /// </summary>
+    internal sealed class SelectionNameComparer : IComparer<ISelectionSymbol>
+    {
+        public static SelectionNameComparer Instance { get; } = new();
+
+        public int Compare(ISelectionSymbol? a, ISelectionSymbol? b)
+        {
+            if (ReferenceEquals(a, b)) return 0;
+            if (a is null) return -1;
+            if (b is null) return 1;
+            var cmp = NaturalSort.Compare(a.EffectiveSourceEntry.Name, b.EffectiveSourceEntry.Name);
+            if (cmp != 0) return cmp;
+            if (a.EffectiveSourceEntry.Name != a.SourceEntry?.Name
+                || b.EffectiveSourceEntry.Name != b.SourceEntry?.Name)
+            {
+                return NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
+            }
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Compares force-level selections by category order first, then by name.
+    /// </summary>
+    internal sealed class ForceSelectionComparer(Dictionary<string, int> categoryOrder) : IComparer<ISelectionSymbol>
+    {
+        public int Compare(ISelectionSymbol? a, ISelectionSymbol? b)
+        {
+            if (ReferenceEquals(a, b)) return 0;
+            if (a is null) return -1;
+            if (b is null) return 1;
+            var aCatId = a.PrimaryCategory?.SourceEntry?.Id;
+            var bCatId = b.PrimaryCategory?.SourceEntry?.Id;
+            int aOrder = aCatId is not null && categoryOrder.TryGetValue(aCatId, out var ao) ? ao : -1;
+            int bOrder = bCatId is not null && categoryOrder.TryGetValue(bCatId, out var bo) ? bo : -1;
+            var cmp = aOrder.CompareTo(bOrder);
+            if (cmp != 0) return cmp;
+            return SelectionNameComparer.Instance.Compare(a, b);
+        }
+    }
+
+    /// <summary>
+    /// Compares forces by name (natural sort).
+    /// </summary>
+    internal sealed class ForceNameComparer : IComparer<IForceSymbol>
+    {
+        public static ForceNameComparer Instance { get; } = new();
+
+        public int Compare(IForceSymbol? a, IForceSymbol? b)
+        {
+            if (ReferenceEquals(a, b)) return 0;
+            if (a is null) return -1;
+            if (b is null) return 1;
+            return NaturalSort.Compare(a.Name, b.Name);
+        }
     }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
@@ -162,6 +162,9 @@ internal static class ConstraintEvaluator
                 ? forceCatalogues[forceIndex]
                 : _compilation.GlobalNamespace.RootCatalogue;
 
+            // Collect force category IDs to filter constraint validation to relevant entries.
+            var forceCategoryIds = GetForceCategoryIds(force);
+
             var sharedChecked = new HashSet<(string constraintId, string entryId)>();
 
             // Walk root-level entries in the catalogue (not descendants)
@@ -170,10 +173,12 @@ internal static class ConstraintEvaluator
             {
                 var targetId = GetTargetEntryId(entry);
                 if (targetId is null) continue;
+
                 var isLink = entry.IsReference && entry.ReferencedEntry is not null;
                 var linkId = entry.Id; // link's own ID (same as targetId if not a link)
 
                 // Hidden entry validation: if entry is hidden but has selections, error
+                // This runs for ALL entries (not filtered by force categories)
                 if (IsEffectivelyHidden(entry, force))
                 {
                     var hiddenCountId = isLink ? linkId! : targetId;
@@ -184,6 +189,11 @@ internal static class ConstraintEvaluator
                             "selection", targetId, targetId, "hidden");
                     }
                 }
+
+                // Skip constraint validation for entries not relevant to this force.
+                var effectiveEntry = entry.ReferencedEntry ?? entry;
+                if (!EntryMatchesForceCategories(effectiveEntry, forceCategoryIds))
+                    continue;
 
                 // Collect all constraints: link's own + shared target's
                 var constraintSources = new List<(IConstraintSymbol constraint, string sourceEntryId, bool isShared)>();
@@ -435,6 +445,13 @@ internal static class ConstraintEvaluator
                     var effectiveAvailValues = GetEffectiveConstraintValues(targetEntry, null, force);
                     var currentCount = counts.GetValueOrDefault(countKey);
 
+                    // Hidden child entry validation: if child is hidden but has selections, error
+                    if (!isGroup && currentCount > 0 && IsEffectivelyHidden(targetEntry, force))
+                    {
+                        _diagnostics.Add(ErrorCode.WRN_MaxSelectionCountViolation, Location.None,
+                            "selection", parentEntryIdForLookup, parentEntryIdForLookup, "hidden");
+                    }
+
                     // Groups with selections still need max constraint evaluation;
                     // entries with selections are handled by the child-selection loop above.
                     if (!isGroup && counts.ContainsKey(countKey)) continue;
@@ -656,6 +673,42 @@ internal static class ConstraintEvaluator
                 foreach (var desc in FlattenSelections(sel.ChildSelections))
                     yield return desc;
             }
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        //  Force category filtering
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Collects the set of category IDs from a force's categories.
+        /// Forces with no categories return an empty set (meaning only
+        /// uncategorized entries should be evaluated).
+        /// </summary>
+        private static HashSet<string> GetForceCategoryIds(ForceSymbol force)
+        {
+            var ids = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var cat in force.Categories)
+            {
+                if (cat.SourceEntry is not IErrorSymbol && cat.SourceEntry.Id is { } catId)
+                    ids.Add(catId);
+            }
+            return ids;
+        }
+
+        /// <summary>
+        /// Checks if an entry's primary category is among the force's declared categories.
+        /// Entries without a primary category are allowed in any force.
+        /// When the force has no categories, only uncategorized entries are allowed.
+        /// </summary>
+        private static bool EntryMatchesForceCategories(
+            ISelectionEntryContainerSymbol entry, HashSet<string> forceCategoryIds)
+        {
+            var primaryCat = entry.PrimaryCategory;
+            if (primaryCat is null)
+                return true;
+
+            var catTarget = primaryCat.ReferencedEntry ?? primaryCat;
+            return catTarget.Id is { } catId && forceCategoryIds.Contains(catId);
         }
 
         // ──────────────────────────────────────────────────────────────────

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
@@ -230,12 +230,15 @@ internal static class ConstraintEvaluator
                             mergedShared[key] = (val, existing.constraintId, existing.comparison);
                     }
                 }
-                // Also merge link constraints into shared if both exist with same type
+                // Also merge link's OWN constraints into shared if both exist with same type.
+                // Only merge the link's own constraints (sourceEntryId != targetId).
+                // Target constraints with shared=false are evaluated independently per-link.
                 if (mergedShared.Count > 0)
                 {
-                    foreach (var (constraint, _, isShared) in constraintSources)
+                    foreach (var (constraint, srcEntryId, isShared) in constraintSources)
                     {
                         if (isShared) continue;
+                        if (srcEntryId == targetId) continue; // target's shared=false → evaluate independently
                         var query = constraint.Query;
                         var cid = constraint.Id ?? "";
                         var val = effectiveValues.GetValueOrDefault(cid, query.ReferenceValue ?? 0m);
@@ -254,9 +257,10 @@ internal static class ConstraintEvaluator
                 var mergedLinkConstraintIds = new HashSet<string>(StringComparer.Ordinal);
                 if (mergedShared.Count > 0)
                 {
-                    foreach (var (constraint, _, isShared) in constraintSources)
+                    foreach (var (constraint, srcEntryId, isShared) in constraintSources)
                     {
                         if (isShared) continue;
+                        if (srcEntryId == targetId) continue; // target's shared=false → not merged
                         var query = constraint.Query;
                         var direction = query.Comparison == QueryComparisonType.GreaterThanOrEqual ? "min" : "max";
                         var key = $"{direction}:{query.ValueKind}:{query.ValueTypeSymbol?.Id}";
@@ -366,18 +370,26 @@ internal static class ConstraintEvaluator
             SelectionSymbol parent,
             ForceSymbol force)
         {
-            // Count children by entry ID and entry group ID
+            // Count children by entry ID and entry group ID.
+            // For collective children, use per-model counts (divide by parent's number).
+            var parentCount = parent.SelectedCount;
             var counts = new Dictionary<CountKey, int>();
             foreach (var child in parent.ChildSelections)
             {
                 if (child.EntryId is not { } childEntryId) continue;
+                var childCount = child.SelectedCount;
+                // Per-model count for collective entries
+                if (parentCount > 0 && IsChildCollective(child))
+                {
+                    childCount /= parentCount;
+                }
                 var entryKey = new CountKey(childEntryId, CountKeyKind.Entry);
-                counts[entryKey] = counts.GetValueOrDefault(entryKey) + child.SelectedCount;
+                counts[entryKey] = counts.GetValueOrDefault(entryKey) + childCount;
                 var groupId = child.EntryGroupId;
                 if (groupId is not null)
                 {
                     var groupKey = new CountKey(groupId, CountKeyKind.Group);
-                    counts[groupKey] = counts.GetValueOrDefault(groupKey) + child.SelectedCount;
+                    counts[groupKey] = counts.GetValueOrDefault(groupKey) + childCount;
                 }
             }
 
@@ -417,10 +429,15 @@ internal static class ConstraintEvaluator
 
                     // For groups, count by entryGroupId; for entries, count by entryId
                     var isGroup = childEntrySymbol is ISelectionEntryGroupSymbol;
-                    if (counts.ContainsKey(new CountKey(childId, isGroup ? CountKeyKind.Group : CountKeyKind.Entry))) continue;
+                    var countKey = new CountKey(childId, isGroup ? CountKeyKind.Group : CountKeyKind.Entry);
 
                     var targetEntry = childEntrySymbol.ReferencedEntry ?? childEntrySymbol;
                     var effectiveAvailValues = GetEffectiveConstraintValues(targetEntry, null, force);
+                    var currentCount = counts.GetValueOrDefault(countKey);
+
+                    // Groups with selections still need max constraint evaluation;
+                    // entries with selections are handled by the child-selection loop above.
+                    if (!isGroup && counts.ContainsKey(countKey)) continue;
 
                     foreach (var constraint in targetEntry.Constraints)
                     {
@@ -430,8 +447,7 @@ internal static class ConstraintEvaluator
 
                         var constraintId = constraint.Id ?? "";
                         var constraintValue = effectiveAvailValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
-                        var count = counts.GetValueOrDefault(new CountKey(childId, isGroup ? CountKeyKind.Group : CountKeyKind.Entry));
-                        CheckConstraint(query.Comparison, constraintValue, count,
+                        CheckConstraint(query.Comparison, constraintValue, currentCount,
                             childId, "selection", parentEntryIdForLookup,
                             constraintId);
                     }
@@ -927,6 +943,33 @@ internal static class ConstraintEvaluator
                 }
             }
             return fallback;
+        }
+
+        /// <summary>
+        /// Checks if a selection's source entry is collective by resolving through
+        /// the entry chain. Used for per-model constraint counting.
+        /// </summary>
+        private static bool IsChildCollective(SelectionSymbol child)
+        {
+            try
+            {
+                var sourceEntry = child.SourceEntry;
+                if (sourceEntry is null) return false;
+                // Check the source entry itself
+                if (sourceEntry.IsCollective) return true;
+                // Check through the effective entry chain (for entry links to collective targets)
+                ISelectionEntryContainerSymbol current = sourceEntry;
+                for (var depth = 0; depth < 32 && current.ReferencedEntry is { } referenced; depth++)
+                {
+                    if (referenced.IsCollective) return true;
+                    current = referenced;
+                }
+                return current.IsCollective;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/EffectiveEntrySymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/EffectiveEntrySymbol.cs
@@ -38,6 +38,7 @@ internal sealed class EffectiveSelectionEntrySymbol : EffectiveContainerEntrySym
     public ICategoryEntrySymbol? PrimaryCategory { get; }
 
     // Delegated from ISelectionEntryContainerSymbol
+    public bool IsCollective => OriginalEntry.IsCollective;
     public ImmutableArray<ISelectionEntryContainerSymbol> ChildSelectionEntries => OriginalEntry.ChildSelectionEntries;
 
     // ISelectionEntryContainerSymbol.ReferencedEntry (explicit for `new` member)

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
@@ -616,9 +616,11 @@ internal sealed class ModifierEvaluator
             if (query.ValueFilterKind == QueryFilterKind.SpecifiedEntry
                 && query.FilterSymbol is ICategoryEntrySymbol)
             {
+                bool descSel = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+                bool descForce = query.Options.HasFlag(QueryOptions.IncludeDescendantForces);
                 var selections = query.ScopeKind == QueryScopeKind.ContainingForce
-                    ? ForceSelections(context.Force!)
-                    : RosterSelections();
+                    ? ForceSelections(context.Force!, descSel, descForce)
+                    : RosterSelections(descSel, descForce);
                 return CheckScopeInstanceOf(query, selections);
             }
             return false;
@@ -713,39 +715,43 @@ internal sealed class ModifierEvaluator
     }
 
     /// <summary>
-    /// All selections under a single force, flattened (top-level + descendants).
+    /// Enumerates selections under a force, optionally including descendant selections
+    /// and/or descendant child forces.
     /// </summary>
-    private static IEnumerable<ISelectionSymbol> ForceSelections(IForceSymbol force)
+    private static IEnumerable<ISelectionSymbol> ForceSelections(
+        IForceSymbol force, bool descendIntoSelections, bool descendIntoForces)
     {
         foreach (var sel in force.Selections)
         {
-            foreach (var item in SelectionWithDescendants(sel))
-                yield return item;
+            if (descendIntoSelections)
+            {
+                foreach (var item in SelectionWithDescendants(sel))
+                    yield return item;
+            }
+            else
+            {
+                yield return sel;
+            }
         }
-    }
-
-    /// <summary>
-    /// All selections under a force and its descendant forces, flattened (recursive).
-    /// </summary>
-    private static IEnumerable<ISelectionSymbol> ForceSelectionsDeep(IForceSymbol force)
-    {
-        foreach (var item in ForceSelections(force))
-            yield return item;
-        foreach (var childForce in force.Forces)
+        if (descendIntoForces)
         {
-            foreach (var item in ForceSelectionsDeep(childForce))
-                yield return item;
+            foreach (var childForce in force.Forces)
+            {
+                foreach (var item in ForceSelections(childForce, descendIntoSelections, descendIntoForces))
+                    yield return item;
+            }
         }
     }
 
     /// <summary>
-    /// All selections in the roster across all forces (including nested forces).
+    /// All selections in the roster across all forces, optionally including
+    /// descendant selections and/or descendant child forces.
     /// </summary>
-    private IEnumerable<ISelectionSymbol> RosterSelections()
+    private IEnumerable<ISelectionSymbol> RosterSelections(bool descendIntoSelections, bool descendIntoForces)
     {
         foreach (var force in _roster.Forces)
         {
-            foreach (var item in ForceSelectionsDeep(force))
+            foreach (var item in ForceSelections(force, descendIntoSelections, descendIntoForces))
                 yield return item;
         }
     }
@@ -756,28 +762,47 @@ internal sealed class ModifierEvaluator
 
     /// <summary>
     /// Direct children of the containing element (siblings in parent scope).
+    /// When <paramref name="descendIntoSelections"/> is true, also includes each sibling's descendants.
     /// </summary>
-    private static IEnumerable<ISelectionSymbol> SiblingSelections(EvalContext context)
+    private static IEnumerable<ISelectionSymbol> SiblingSelections(EvalContext context, bool descendIntoSelections)
     {
         if (context.Selection is null)
         {
             if (context.Force is not null)
             {
                 foreach (var s in context.Force.Selections)
-                    yield return s;
+                {
+                    if (descendIntoSelections)
+                    {
+                        foreach (var item in SelectionWithDescendants(s))
+                            yield return item;
+                    }
+                    else
+                    {
+                        yield return s;
+                    }
+                }
             }
             yield break;
         }
         var parent = context.Selection.ContainingSymbol;
-        if (parent is ISelectionSymbol parentSel)
+        var siblings = parent switch
         {
-            foreach (var s in parentSel.Selections)
-                yield return s;
-        }
-        else if (parent is IForceSymbol parentForce)
+            ISelectionSymbol parentSel => parentSel.Selections,
+            IForceSymbol parentForce => parentForce.Selections,
+            _ => Enumerable.Empty<ISelectionSymbol>(),
+        };
+        foreach (var s in siblings)
         {
-            foreach (var s in parentForce.Selections)
+            if (descendIntoSelections)
+            {
+                foreach (var item in SelectionWithDescendants(s))
+                    yield return item;
+            }
+            else
+            {
                 yield return s;
+            }
         }
     }
 
@@ -785,7 +810,8 @@ internal sealed class ModifierEvaluator
     /// Walk up ancestry to find matching entry, return its subtree.
     /// Falls back to roster selections when no scopeId is specified.
     /// </summary>
-    private IEnumerable<ISelectionSymbol> AncestorSelections(IQuerySymbol query, EvalContext context)
+    private IEnumerable<ISelectionSymbol> AncestorSelections(
+        IQuerySymbol query, EvalContext context, bool descendIntoSelections, bool descendIntoForces)
     {
         if (context.Selection is null || context.Force is null)
             yield break;
@@ -793,7 +819,7 @@ internal sealed class ModifierEvaluator
         var scopeId = query.ScopeSymbol?.Id;
         if (scopeId is null)
         {
-            foreach (var sel in RosterSelections())
+            foreach (var sel in RosterSelections(descendIntoSelections, descendIntoForces))
                 yield return sel;
             yield break;
         }
@@ -817,19 +843,20 @@ internal sealed class ModifierEvaluator
 
     private IEnumerable<ISelectionSymbol> GetSelectionsInScope(IQuerySymbol query, EvalContext context)
     {
+        bool descSel = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+        bool descForce = query.Options.HasFlag(QueryOptions.IncludeDescendantForces);
         return query.ScopeKind switch
         {
             QueryScopeKind.Self => context.Selection is { } s ? [s] : [],
-            QueryScopeKind.Parent => SiblingSelections(context),
-            QueryScopeKind.ContainingForce => context.Force is null ? [] :
-                query.Options.HasFlag(QueryOptions.IncludeDescendantForces)
-                    ? ForceSelectionsDeep(context.Force)
-                    : ForceSelections(context.Force),
-            QueryScopeKind.ContainingRoster => RosterSelections(),
-            QueryScopeKind.ContainingAncestor => AncestorSelections(query, context),
-            QueryScopeKind.ReferencedEntry => FilterByReferencedEntry(query),
-            QueryScopeKind.PrimaryCategory => FilterByPrimaryCategory(context),
-            QueryScopeKind.PrimaryCatalogue => context.Force is null ? [] : ForceSelections(context.Force),
+            QueryScopeKind.Parent => SiblingSelections(context, descSel),
+            QueryScopeKind.ContainingForce => context.Force is null ? []
+                : ForceSelections(context.Force, descSel, descForce),
+            QueryScopeKind.ContainingRoster => RosterSelections(descSel, descForce),
+            QueryScopeKind.ContainingAncestor => AncestorSelections(query, context, descSel, descForce),
+            QueryScopeKind.ReferencedEntry => FilterByReferencedEntry(query, descSel, descForce),
+            QueryScopeKind.PrimaryCategory => FilterByPrimaryCategory(context, descSel, descForce),
+            QueryScopeKind.PrimaryCatalogue => context.Force is null ? []
+                : ForceSelections(context.Force, descSel, descendIntoForces: false),
             _ => [],
         };
     }
@@ -837,13 +864,14 @@ internal sealed class ModifierEvaluator
     /// <summary>
     /// Roster selections filtered to those matching a referenced entry/group.
     /// </summary>
-    private IEnumerable<ISelectionSymbol> FilterByReferencedEntry(IQuerySymbol query)
+    private IEnumerable<ISelectionSymbol> FilterByReferencedEntry(
+        IQuerySymbol query, bool descendIntoSelections, bool descendIntoForces)
     {
         var entryId = query.ScopeSymbol?.Id;
         if (entryId is null)
             yield break;
 
-        foreach (var sel in RosterSelections())
+        foreach (var sel in RosterSelections(descendIntoSelections, descendIntoForces))
         {
             if (MatchesEntryOrGroup(sel, entryId))
                 yield return sel;
@@ -853,7 +881,8 @@ internal sealed class ModifierEvaluator
     /// <summary>
     /// Force selections filtered to those sharing the current selection's primary category.
     /// </summary>
-    private IEnumerable<ISelectionSymbol> FilterByPrimaryCategory(EvalContext context)
+    private static IEnumerable<ISelectionSymbol> FilterByPrimaryCategory(
+        EvalContext context, bool descendIntoSelections, bool descendIntoForces)
     {
         if (context.Selection is null || context.Force is null)
             yield break;
@@ -862,7 +891,7 @@ internal sealed class ModifierEvaluator
         if (primaryCat is null)
             yield break;
 
-        foreach (var sel in ForceSelections(context.Force))
+        foreach (var sel in ForceSelections(context.Force, descendIntoSelections, descendIntoForces))
         {
             if (SelectionHasCategory(sel, primaryCat))
                 yield return sel;

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
@@ -617,8 +617,8 @@ internal sealed class ModifierEvaluator
                 && query.FilterSymbol is ICategoryEntrySymbol)
             {
                 var selections = query.ScopeKind == QueryScopeKind.ContainingForce
-                    ? GetForceSelections(context)
-                    : GetRosterSelections();
+                    ? ForceSelections(context.Force!)
+                    : RosterSelections();
                 return CheckScopeInstanceOf(query, selections);
             }
             return false;
@@ -695,32 +695,69 @@ internal sealed class ModifierEvaluator
         };
     }
 
-    private IEnumerable<ISelectionSymbol> GetSelectionsInScope(IQuerySymbol query, EvalContext context)
+    // ──────────────────────────────────────────────────────────────────
+    //  Layer 1: Tree traversal primitives (pure, static, reusable)
+    // ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Yields a selection and all its recursive descendants (subtree flattened).
+    /// </summary>
+    private static IEnumerable<ISelectionSymbol> SelectionWithDescendants(ISelectionSymbol selection)
     {
-        return query.ScopeKind switch
+        yield return selection;
+        foreach (var child in selection.Selections)
         {
-            QueryScopeKind.Self => GetSelfSelections(context),
-            QueryScopeKind.Parent => GetParentSelections(context),
-            QueryScopeKind.ContainingForce => GetForceSelections(context,
-                includeDescendantForces: query.Options.HasFlag(QueryOptions.IncludeDescendantForces)),
-            QueryScopeKind.ContainingRoster => GetRosterSelections(),
-            QueryScopeKind.ContainingAncestor => GetAncestorSelections(query, context),
-            QueryScopeKind.ReferencedEntry => GetReferencedEntrySelections(query),
-            QueryScopeKind.PrimaryCategory => GetPrimaryCategorySelections(context),
-            // primary-catalogue scope: count across all selections in the force's primary catalogue.
-            // Since a force's catalogue IS its primary catalogue, this is equivalent to force scope.
-            QueryScopeKind.PrimaryCatalogue => GetForceSelections(context),
-            _ => [],
-        };
+            foreach (var desc in SelectionWithDescendants(child))
+                yield return desc;
+        }
     }
 
-    private IEnumerable<ISelectionSymbol> GetSelfSelections(EvalContext context)
+    /// <summary>
+    /// All selections under a single force, flattened (top-level + descendants).
+    /// </summary>
+    private static IEnumerable<ISelectionSymbol> ForceSelections(IForceSymbol force)
     {
-        if (context.Selection is { } sel)
-            yield return sel;
+        foreach (var sel in force.Selections)
+        {
+            foreach (var item in SelectionWithDescendants(sel))
+                yield return item;
+        }
     }
 
-    private IEnumerable<ISelectionSymbol> GetParentSelections(EvalContext context)
+    /// <summary>
+    /// All selections under a force and its descendant forces, flattened (recursive).
+    /// </summary>
+    private static IEnumerable<ISelectionSymbol> ForceSelectionsDeep(IForceSymbol force)
+    {
+        foreach (var item in ForceSelections(force))
+            yield return item;
+        foreach (var childForce in force.Forces)
+        {
+            foreach (var item in ForceSelectionsDeep(childForce))
+                yield return item;
+        }
+    }
+
+    /// <summary>
+    /// All selections in the roster across all forces (including nested forces).
+    /// </summary>
+    private IEnumerable<ISelectionSymbol> RosterSelections()
+    {
+        foreach (var force in _roster.Forces)
+        {
+            foreach (var item in ForceSelectionsDeep(force))
+                yield return item;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    //  Layer 2: Context-aware scope resolution
+    // ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Direct children of the containing element (siblings in parent scope).
+    /// </summary>
+    private static IEnumerable<ISelectionSymbol> SiblingSelections(EvalContext context)
     {
         if (context.Selection is null)
         {
@@ -731,92 +768,42 @@ internal sealed class ModifierEvaluator
             }
             yield break;
         }
-        // Parent is just ContainingSymbol
         var parent = context.Selection.ContainingSymbol;
         if (parent is ISelectionSymbol parentSel)
         {
-            // Return siblings (parent's children)
             foreach (var s in parentSel.Selections)
                 yield return s;
         }
         else if (parent is IForceSymbol parentForce)
         {
-            // Root selection — parent is force, return force-level selections
             foreach (var s in parentForce.Selections)
                 yield return s;
         }
     }
 
-    private IEnumerable<ISelectionSymbol> GetForceSelections(EvalContext context, bool includeDescendantForces = false)
+    /// <summary>
+    /// Walk up ancestry to find matching entry, return its subtree.
+    /// Falls back to roster selections when no scopeId is specified.
+    /// </summary>
+    private IEnumerable<ISelectionSymbol> AncestorSelections(IQuerySymbol query, EvalContext context)
     {
-        if (context.Force is null)
-            yield break;
-
-        foreach (var sel in context.Force.Selections)
-        {
-            yield return sel;
-            foreach (var desc in GetDescendantSelections(sel))
-                yield return desc;
-        }
-
-        if (includeDescendantForces)
-        {
-            foreach (var sel in GetChildForceSelections(context.Force))
-                yield return sel;
-        }
-    }
-
-    private static IEnumerable<ISelectionSymbol> GetChildForceSelections(IForceSymbol force)
-    {
-        foreach (var childForce in force.Forces)
-        {
-            foreach (var sel in childForce.Selections)
-            {
-                yield return sel;
-                foreach (var desc in GetDescendantSelections(sel))
-                    yield return desc;
-            }
-            foreach (var sel in GetChildForceSelections(childForce))
-                yield return sel;
-        }
-    }
-
-    private IEnumerable<ISelectionSymbol> GetRosterSelections()
-    {
-        foreach (var force in _roster.Forces)
-        {
-            foreach (var sel in force.Selections)
-            {
-                yield return sel;
-                foreach (var desc in GetDescendantSelections(sel))
-                    yield return desc;
-            }
-        }
-    }
-
-    private IEnumerable<ISelectionSymbol> GetAncestorSelections(IQuerySymbol query, EvalContext context)
-    {
-        // Ancestor scope: walk up from current selection to find matching ancestor
         if (context.Selection is null || context.Force is null)
             yield break;
 
         var scopeId = query.ScopeSymbol?.Id;
         if (scopeId is null)
         {
-            // No specific ancestor — return roster-level selections
-            foreach (var sel in GetRosterSelections())
+            foreach (var sel in RosterSelections())
                 yield return sel;
             yield break;
         }
 
-        // Walk up ContainingSymbol chain looking for matching ancestor
         for (ISymbol? sym = context.Selection; sym is not null; sym = sym.ContainingSymbol)
         {
             if (sym is ISelectionSymbol selSym && MatchesEntryOrGroup(selSym, scopeId))
             {
-                yield return selSym;
-                foreach (var desc in GetDescendantSelections(selSym))
-                    yield return desc;
+                foreach (var item in SelectionWithDescendants(selSym))
+                    yield return item;
                 yield break;
             }
             if (sym is IForceSymbol)
@@ -824,46 +811,61 @@ internal sealed class ModifierEvaluator
         }
     }
 
-    private IEnumerable<ISelectionSymbol> GetReferencedEntrySelections(IQuerySymbol query)
+    // ──────────────────────────────────────────────────────────────────
+    //  Layer 3: Scope dispatch + scope filters
+    // ──────────────────────────────────────────────────────────────────
+
+    private IEnumerable<ISelectionSymbol> GetSelectionsInScope(IQuerySymbol query, EvalContext context)
     {
-        // Scope is a specific entry — find all selections matching that entry across the roster
+        return query.ScopeKind switch
+        {
+            QueryScopeKind.Self => context.Selection is { } s ? [s] : [],
+            QueryScopeKind.Parent => SiblingSelections(context),
+            QueryScopeKind.ContainingForce => context.Force is null ? [] :
+                query.Options.HasFlag(QueryOptions.IncludeDescendantForces)
+                    ? ForceSelectionsDeep(context.Force)
+                    : ForceSelections(context.Force),
+            QueryScopeKind.ContainingRoster => RosterSelections(),
+            QueryScopeKind.ContainingAncestor => AncestorSelections(query, context),
+            QueryScopeKind.ReferencedEntry => FilterByReferencedEntry(query),
+            QueryScopeKind.PrimaryCategory => FilterByPrimaryCategory(context),
+            QueryScopeKind.PrimaryCatalogue => context.Force is null ? [] : ForceSelections(context.Force),
+            _ => [],
+        };
+    }
+
+    /// <summary>
+    /// Roster selections filtered to those matching a referenced entry/group.
+    /// </summary>
+    private IEnumerable<ISelectionSymbol> FilterByReferencedEntry(IQuerySymbol query)
+    {
         var entryId = query.ScopeSymbol?.Id;
         if (entryId is null)
             yield break;
 
-        foreach (var sel in GetRosterSelections())
+        foreach (var sel in RosterSelections())
         {
             if (MatchesEntryOrGroup(sel, entryId))
                 yield return sel;
         }
     }
 
-    private IEnumerable<ISelectionSymbol> GetPrimaryCategorySelections(EvalContext context)
+    /// <summary>
+    /// Force selections filtered to those sharing the current selection's primary category.
+    /// </summary>
+    private IEnumerable<ISelectionSymbol> FilterByPrimaryCategory(EvalContext context)
     {
-        // Find the primary category of the current selection's root,
-        // then find all selections in the force with that category
         if (context.Selection is null || context.Force is null)
             yield break;
 
         var primaryCat = context.Selection.PrimaryCategory?.SourceEntry?.Id;
-
         if (primaryCat is null)
             yield break;
 
-        foreach (var sel in GetForceSelections(context))
+        foreach (var sel in ForceSelections(context.Force))
         {
             if (SelectionHasCategory(sel, primaryCat))
                 yield return sel;
-        }
-    }
-
-    private static IEnumerable<ISelectionSymbol> GetDescendantSelections(ISelectionSymbol sel)
-    {
-        foreach (var child in sel.Selections)
-        {
-            yield return child;
-            foreach (var desc in GetDescendantSelections(child))
-                yield return desc;
         }
     }
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
@@ -701,11 +701,15 @@ internal sealed class ModifierEvaluator
         {
             QueryScopeKind.Self => GetSelfSelections(context),
             QueryScopeKind.Parent => GetParentSelections(context),
-            QueryScopeKind.ContainingForce => GetForceSelections(context),
+            QueryScopeKind.ContainingForce => GetForceSelections(context,
+                includeDescendantForces: query.Options.HasFlag(QueryOptions.IncludeDescendantForces)),
             QueryScopeKind.ContainingRoster => GetRosterSelections(),
             QueryScopeKind.ContainingAncestor => GetAncestorSelections(query, context),
             QueryScopeKind.ReferencedEntry => GetReferencedEntrySelections(query),
             QueryScopeKind.PrimaryCategory => GetPrimaryCategorySelections(context),
+            // primary-catalogue scope: count across all selections in the force's primary catalogue.
+            // Since a force's catalogue IS its primary catalogue, this is equivalent to force scope.
+            QueryScopeKind.PrimaryCatalogue => GetForceSelections(context),
             _ => [],
         };
     }
@@ -743,7 +747,7 @@ internal sealed class ModifierEvaluator
         }
     }
 
-    private IEnumerable<ISelectionSymbol> GetForceSelections(EvalContext context)
+    private IEnumerable<ISelectionSymbol> GetForceSelections(EvalContext context, bool includeDescendantForces = false)
     {
         if (context.Force is null)
             yield break;
@@ -753,6 +757,27 @@ internal sealed class ModifierEvaluator
             yield return sel;
             foreach (var desc in GetDescendantSelections(sel))
                 yield return desc;
+        }
+
+        if (includeDescendantForces)
+        {
+            foreach (var sel in GetChildForceSelections(context.Force))
+                yield return sel;
+        }
+    }
+
+    private static IEnumerable<ISelectionSymbol> GetChildForceSelections(IForceSymbol force)
+    {
+        foreach (var childForce in force.Forces)
+        {
+            foreach (var sel in childForce.Selections)
+            {
+                yield return sel;
+                foreach (var desc in GetDescendantSelections(sel))
+                    yield return desc;
+            }
+            foreach (var sel in GetChildForceSelections(childForce))
+                yield return sel;
         }
     }
 
@@ -938,8 +963,12 @@ internal sealed class ModifierEvaluator
         if (filterId is null)
             return false;
 
+        // shared=true: segment-based matching (any segment of "linkId::targetId" can match)
+        // shared=false: exact matching only (composite IDs like "link::target" won't match base "target")
+        bool isShared = query.Options.HasFlag(QueryOptions.SharedConstraint);
+
         // Check if selection's entry matches
-        if (MatchesEntryOrGroup(sel, filterId))
+        if (isShared ? MatchesEntryOrGroup(sel, filterId) : MatchesEntryOrGroupExact(sel, filterId))
             return true;
 
         // Check if selection has a category matching the filter
@@ -947,6 +976,13 @@ internal sealed class ModifierEvaluator
             return true;
 
         return false;
+    }
+
+    private static bool MatchesEntryOrGroupExact(ISelectionSymbol sel, string id)
+    {
+        if (sel.EntryGroupId == id)
+            return true;
+        return sel.EntryId == id;
     }
 
     private static bool MatchesEntry(ISelectionSymbol sel, string? entryId)
@@ -992,6 +1028,17 @@ internal sealed class ModifierEvaluator
                 return 0;
 
             var value = CalculateQueryValue(query, context);
+
+            // percentValue: scale referenceValue to an absolute threshold
+            // e.g. value=25, total=5 → threshold=5*25/100=1.25; count=4; floor(4/1.25)=3
+            if (query.Options.HasFlag(QueryOptions.ValuePercentage))
+            {
+                var total = CountTotalSelectionsInScope(query, context);
+                referenceValue = total * referenceValue / 100m;
+                if (referenceValue == 0)
+                    return 0;
+            }
+
             var roundUp = query.Options.HasFlag(QueryOptions.ValueRoundUp);
 
             var repeats = value / referenceValue;
@@ -1000,15 +1047,13 @@ internal sealed class ModifierEvaluator
         }
 
         // Check repeat children (ModifierEffectBaseSymbol.Effects → RepeatEffectSymbol)
+        // Multiple repeats are additive: total = sum of each child's repeat count.
         if (effect.Effects.Length > 0)
         {
-            int totalRepeats = 1;
+            int totalRepeats = 0;
             foreach (var repeatEffect in effect.Effects)
             {
-                var childRepeat = GetRepeatCount(repeatEffect, context);
-                if (childRepeat == 0)
-                    return 0; // Any zero repeat means skip entirely
-                totalRepeats = childRepeat;
+                totalRepeats += GetRepeatCount(repeatEffect, context);
             }
             return totalRepeats;
         }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/QueryBaseSymbol.cs
@@ -142,7 +142,7 @@ internal abstract partial class QueryBaseSymbol : LogicBaseSymbol, IQuerySymbol
         get
         {
             if (ValueFilterKind is QueryFilterKind.SpecifiedEntry)
-                return GetBoundField(ref lazyFilter, this, static (b, d, self) => b.BindFilterEntrySymbol(self.Declaration, ((QueryFilteredBaseNode)self.Declaration).ChildId, self.ScopeKind, d));
+                return GetBoundField(ref lazyFilter, this, static (b, d, self) => b.BindFilterEntrySymbol(self.Declaration, ((QueryFilteredBaseNode)self.Declaration).ChildId, d));
             return null;
         }
     }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryBaseSymbol.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/SelectionEntryBaseSymbol.cs
@@ -10,6 +10,7 @@ internal abstract class SelectionEntryBaseSymbol : ContainerEntryBaseSymbol, ISe
         DiagnosticBag diagnostics)
         : base(containingSymbol, declaration, diagnostics)
     {
+        IsCollective = declaration.Collective;
         Categories = CreateCategoryEntries().ToImmutableArray();
         PrimaryCategory = Categories.FirstOrDefault(x => x.IsPrimaryCategory);
         ChildSelectionEntries = CreateSelectionEntryContainers().ToImmutableArray();
@@ -39,6 +40,8 @@ internal abstract class SelectionEntryBaseSymbol : ContainerEntryBaseSymbol, ISe
     }
 
     public override ISelectionEntryContainerSymbol? ReferencedEntry => null;
+
+    public bool IsCollective { get; }
 
     public CategoryLinkSymbol? PrimaryCategory { get; }
 

--- a/src/WarHub.ArmouryModel.Extensions/Symbols/ISelectionEntryContainerSymbol.cs
+++ b/src/WarHub.ArmouryModel.Extensions/Symbols/ISelectionEntryContainerSymbol.cs
@@ -7,6 +7,11 @@ namespace WarHub.ArmouryModel;
 /// </summary>
 public interface ISelectionEntryContainerSymbol : IContainerEntrySymbol
 {
+    /// <summary>
+    /// Whether this entry is collective (per-model semantics for number operations).
+    /// </summary>
+    bool IsCollective { get; }
+
     ICategoryEntrySymbol? PrimaryCategory { get; }
 
     ImmutableArray<ICategoryEntrySymbol> Categories { get; }

--- a/src/WarHub.ArmouryModel.RosterEngine.Spec/ProtocolConverter.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine.Spec/ProtocolConverter.cs
@@ -215,7 +215,7 @@ public static class ProtocolConverter
     {
         Id = c.Id,
         Type = ParseConstraintKind(c.Type),
-        Value = (decimal)c.Value,
+        Value = c.Value,
         Field = c.Field,
         Scope = c.Scope,
         Shared = c.Shared,
@@ -246,7 +246,7 @@ public static class ProtocolConverter
     private static ConditionCore ConvertCondition(ProtocolCondition c) => new()
     {
         Type = ParseConditionKind(c.Type),
-        Value = (decimal)c.Value,
+        Value = c.Value,
         Field = c.Field,
         Scope = c.Scope,
         ChildId = c.ChildId,
@@ -265,7 +265,7 @@ public static class ProtocolConverter
 
     private static RepeatCore ConvertRepeat(ProtocolRepeat r) => new()
     {
-        Value = (decimal)r.Value,
+        Value = r.Value,
         RepeatCount = r.Repeats,
         Field = r.Field,
         Scope = r.Scope,
@@ -355,7 +355,7 @@ public static class ProtocolConverter
     {
         Id = ct.Id,
         Name = ct.Name,
-        DefaultCostLimit = ct.DefaultCostLimit is { } limit ? (decimal)limit : -1m,
+        DefaultCostLimit = ct.DefaultCostLimit is { } limit ? limit : -1m,
         Hidden = ct.Hidden,
     };
 
@@ -363,7 +363,7 @@ public static class ProtocolConverter
     {
         Name = cv.Name,
         TypeId = cv.TypeId,
-        Value = (decimal)cv.Value,
+        Value = cv.Value,
     };
 
     private static ProfileTypeCore ConvertProfileType(ProtocolProfileType pt) => new()

--- a/src/WarHub.ArmouryModel.RosterEngine.Spec/SpecRosterEngineAdapter.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine.Spec/SpecRosterEngineAdapter.cs
@@ -20,13 +20,16 @@ public sealed class SpecRosterEngineAdapter : IRosterEngine
     private WhamRosterEngine? _coreEngine;
     private WhamRosterState? _state;
     private WhamCompilation? _catalogCompilation;
+    private string? _specId;
+
+    public void SetTestContext(string specId) => _specId = specId;
 
     public IReadOnlyList<string> Setup(ProtocolGameSystem gameSystem, ProtocolCatalogue[] catalogues)
     {
         var compilation = ProtocolConverter.CreateCompilation(gameSystem, catalogues);
         _catalogCompilation = compilation;
         _coreEngine = new WhamRosterEngine();
-        _state = _coreEngine.CreateRoster(compilation);
+        _state = _coreEngine.CreateRoster(compilation, _specId);
         return [];
     }
 
@@ -118,9 +121,9 @@ public sealed class SpecRosterEngineAdapter : IRosterEngine
         return new ActionOutputs { ForceId = result.ForceId! };
     }
 
-    public void SetCostLimit(string costTypeId, double value)
+    public void SetCostLimit(string costTypeId, decimal value)
     {
-        _state = EnsureEngine().SetCostLimit(EnsureState(), costTypeId, (decimal)value);
+        _state = EnsureEngine().SetCostLimit(EnsureState(), costTypeId, value);
     }
 
     public void SetCustomization(string forceId, string? selectionId, string? categoryEntryId,

--- a/src/WarHub.ArmouryModel.RosterEngine.Spec/StateMapper.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine.Spec/StateMapper.cs
@@ -328,7 +328,7 @@ internal sealed class StateMapper
             costs.Add(new CostState(
                 Name: cost.Name,
                 TypeId: typeId,
-                Value: (double)(cost.Value * selectedCount)));
+                Value: cost.Value * selectedCount));
         }
         // BattleScribe emits all referenced cost types on every selection, filling 0 for missing ones
         foreach (var (typeId, name) in costTypeNames)
@@ -348,7 +348,7 @@ internal sealed class StateMapper
         List<ForceState> mappedForces,
         IReadOnlySet<string> referencedCostTypeIds)
     {
-        var totals = new Dictionary<string, double>(StringComparer.Ordinal);
+        var totals = new Dictionary<string, decimal>(StringComparer.Ordinal);
         foreach (var force in mappedForces)
         {
             AggregateCostsFromSelections(force.Selections, totals);
@@ -379,7 +379,7 @@ internal sealed class StateMapper
                 result.Add(new CostState(
                     Name: rosterCost.Name,
                     TypeId: rosterCost.CostType.Id!,
-                    Value: (double)limit));
+                    Value: limit));
             }
         }
         return result;
@@ -387,7 +387,7 @@ internal sealed class StateMapper
 
     private static void AggregateCostsFromSelections(
         IReadOnlyList<SelectionState> selections,
-        Dictionary<string, double> totals)
+        Dictionary<string, decimal> totals)
     {
         foreach (var sel in selections)
         {

--- a/src/WarHub.ArmouryModel.RosterEngine/EntryResolver.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/EntryResolver.cs
@@ -99,17 +99,29 @@ public static class EntryResolver
     /// The parent entry whose children to enumerate.
     /// If the entry is a link, it is resolved first via <see cref="ResolveEntry"/>.
     /// </param>
+    /// <param name="contextLinkPrefix">
+    /// The link prefix context of <paramref name="entry"/> itself (from parent links above it).
+    /// When <paramref name="entry"/> is itself a link, its ID is appended to this prefix
+    /// to form the prefix propagated to its children.
+    /// </param>
     /// <returns>An ordered, flattened list of child entries.</returns>
-    public static IReadOnlyList<AvailableEntry> GetChildEntries(ISelectionEntryContainerSymbol entry)
+    public static IReadOnlyList<AvailableEntry> GetChildEntries(
+        ISelectionEntryContainerSymbol entry,
+        string contextLinkPrefix = "")
     {
         var result = new List<AvailableEntry>();
 
         // Resolve through links to get the effective container with children.
         var effective = ResolveEntry(entry);
 
+        // If this entry is a link, children accumulate its ID into the prefix.
+        var childPrefix = entry.ReferencedEntry is not null
+            ? JoinLinkPrefix(contextLinkPrefix, entry.Id!)
+            : contextLinkPrefix;
+
         foreach (var child in effective.ChildSelectionEntries)
         {
-            AddEntryOrFlatten(child, result, sourceGroup: null);
+            AddEntryOrFlatten(child, result, sourceGroup: null, parentLinkPrefix: childPrefix);
         }
 
         return result;
@@ -118,6 +130,7 @@ public static class EntryResolver
     /// <summary>
     /// Filters <see cref="ICatalogueSymbol.RootContainerEntries"/> to selection entry
     /// containers and adds them to <paramref name="result"/>, flattening groups encountered.
+    /// Root entries have no link prefix context (they are at the catalogue root level).
     /// </summary>
     private static void AddRootSelectionEntries(
         ImmutableArray<IContainerEntrySymbol> rootEntries,
@@ -127,7 +140,7 @@ public static class EntryResolver
         {
             if (entry is ISelectionEntryContainerSymbol selEntry)
             {
-                AddEntryOrFlatten(selEntry, result, sourceGroup: null);
+                AddEntryOrFlatten(selEntry, result, sourceGroup: null, parentLinkPrefix: "");
             }
             // IForceEntrySymbol and ICategoryEntrySymbol are silently skipped.
         }
@@ -136,17 +149,30 @@ public static class EntryResolver
     /// <summary>
     /// Adds a single concrete entry to the result, or recursively flattens a group.
     /// </summary>
+    /// <param name="entry">The entry to add or flatten.</param>
+    /// <param name="result">The result list to populate.</param>
+    /// <param name="sourceGroup">The enclosing group (set on flattened children).</param>
+    /// <param name="parentLinkPrefix">
+    /// The accumulated link prefix from parent links above this entry.
+    /// When <paramref name="entry"/> is itself a link to a group, its ID extends the prefix
+    /// for the group's children.
+    /// </param>
     private static void AddEntryOrFlatten(
         ISelectionEntryContainerSymbol entry,
         List<AvailableEntry> result,
-        ISelectionEntryGroupSymbol? sourceGroup)
+        ISelectionEntryGroupSymbol? sourceGroup,
+        string parentLinkPrefix = "")
     {
         var resolved = ResolveEntry(entry);
 
         if (resolved is ISelectionEntryGroupSymbol group)
         {
-            // The target is a group — flatten its children.
-            FlattenGroup(group, result, visited: null);
+            // The target is a group — compute the prefix for the group's children.
+            // If this entry is a link to the group, the link's ID is added to the prefix.
+            var groupPrefix = entry.ReferencedEntry is not null
+                ? JoinLinkPrefix(parentLinkPrefix, entry.Id!)
+                : parentLinkPrefix;
+            FlattenGroup(group, result, visited: null, groupLinkPrefix: groupPrefix);
         }
         else
         {
@@ -155,6 +181,7 @@ public static class EntryResolver
             {
                 Symbol = entry,
                 SourceGroup = sourceGroup,
+                LinkPrefix = parentLinkPrefix,
             });
         }
     }
@@ -165,10 +192,18 @@ public static class EntryResolver
     /// <see cref="AvailableEntry.SourceGroup"/>.
     /// A visited-set prevents infinite recursion on self-referencing groups.
     /// </summary>
+    /// <param name="group">The group to flatten.</param>
+    /// <param name="result">The result list to populate.</param>
+    /// <param name="visited">Set of visited group IDs (cycle guard).</param>
+    /// <param name="groupLinkPrefix">
+    /// The accumulated link prefix for entries inside this group.
+    /// This includes the IDs of all links traversed to reach this group.
+    /// </param>
     private static void FlattenGroup(
         ISelectionEntryGroupSymbol group,
         List<AvailableEntry> result,
-        HashSet<string>? visited)
+        HashSet<string>? visited,
+        string groupLinkPrefix = "")
     {
         if (group.Id is not null)
         {
@@ -182,7 +217,11 @@ public static class EntryResolver
 
             if (resolved is ISelectionEntryGroupSymbol childGroup)
             {
-                FlattenGroup(childGroup, result, visited);
+                // Nested group: if the child is a link to the group, extend the prefix.
+                var nestedPrefix = child.ReferencedEntry is not null
+                    ? JoinLinkPrefix(groupLinkPrefix, child.Id!)
+                    : groupLinkPrefix;
+                FlattenGroup(childGroup, result, visited, nestedPrefix);
             }
             else
             {
@@ -190,10 +229,18 @@ public static class EntryResolver
                 {
                     Symbol = child,
                     SourceGroup = group,
+                    LinkPrefix = groupLinkPrefix,
                 });
             }
         }
     }
+
+    /// <summary>
+    /// Joins a link prefix with an ID, using the "::" separator.
+    /// When the prefix is empty, returns the ID directly.
+    /// </summary>
+    internal static string JoinLinkPrefix(string prefix, string id)
+        => string.IsNullOrEmpty(prefix) ? id : $"{prefix}::{id}";
 
     /// <summary>
     /// Follows the <see cref="ISelectionEntryContainerSymbol.ReferencedEntry"/> chain
@@ -211,12 +258,33 @@ public static class EntryResolver
     }
 
     /// <summary>
+    /// Computes the full composite entryId for an available entry, incorporating any link prefix.
+    /// For link entries: <c>linkPrefix::linkId::targetId</c>.
+    /// For direct entries: <c>linkPrefix::entryId</c> (prefix may be empty).
+    /// </summary>
+    public static string ComputeCompositeEntryId(AvailableEntry avail)
+    {
+        var entry = avail.Symbol;
+        var prefix = avail.LinkPrefix;
+        if (entry.ReferencedEntry is { Id: { } targetId })
+        {
+            return JoinLinkPrefix(JoinLinkPrefix(prefix, entry.Id ?? ""), targetId);
+        }
+        return JoinLinkPrefix(prefix, entry.Id ?? "");
+    }
+
+    /// <summary>
     /// Finds an available entry by matching the definition entry ID.
-    /// Matches against the entry's own ID first, then against the resolved
-    /// (link target) ID as a fallback.
+    /// First tries to match against each entry's computed composite entryId
+    /// (which incorporates any link prefix), then falls back to matching
+    /// the entry's own ID or resolved target ID directly.
     /// </summary>
     public static AvailableEntry FindByEntryId(IReadOnlyList<AvailableEntry> available, string entryId)
     {
+        foreach (var avail in available)
+        {
+            if (ComputeCompositeEntryId(avail) == entryId) return avail;
+        }
         foreach (var avail in available)
         {
             if (avail.Symbol.Id == entryId) return avail;
@@ -252,4 +320,11 @@ public sealed class AvailableEntry
     /// <see cref="Source.SelectionNode"/>.
     /// </summary>
     public ISelectionEntryGroupSymbol? SourceGroup { get; init; }
+
+    /// <summary>
+    /// The accumulated link prefix from all link entries traversed above this entry.
+    /// When non-empty, this prefix is prepended to the entry's own ID path to form
+    /// the composite <c>entryId</c> written into the roster selection node.
+    /// </summary>
+    public string LinkPrefix { get; init; } = "";
 }

--- a/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
@@ -944,6 +944,33 @@ public sealed class WhamRosterEngine
     //  larger, consider building an ID-to-symbol index.
     // ──────────────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Finds force and selection symbols for a given force/selection ID pair.
+    /// Returns nulls for any part not found or when roster symbol is unavailable.
+    /// </summary>
+    private static SelectionContext FindSelectionContext(
+        IRosterSymbol? rosterSymbol, string forceId, string selectionId)
+    {
+        if (rosterSymbol is null)
+            return default;
+        var forceSymbol = FindForceSymbolDeep(rosterSymbol, forceId);
+        if (forceSymbol is null)
+            return default;
+        var selSymbol = FindSelectionSymbolDeep(forceSymbol, selectionId);
+        return new(forceSymbol, selSymbol);
+    }
+
+    private readonly record struct SelectionContext(
+        IForceSymbol? Force,
+        ISelectionSymbol? Selection)
+    {
+        /// <summary>
+        /// The parent selection, or null if this is a force-level selection.
+        /// </summary>
+        public ISelectionSymbol? ParentSelection =>
+            Selection?.ContainingSymbol as ISelectionSymbol;
+    }
+
     private static IForceSymbol? FindForceSymbolDeep(IRosterSymbol roster, string forceId)
     {
         foreach (var force in roster.Forces)
@@ -1239,30 +1266,19 @@ public sealed class WhamRosterEngine
         var force = FindForceDeepRequired(roster, forceId);
         var selNode = FindSelectionDeepRequired(force, forceId, selectionId);
 
-        // Check if this is a collective entry with a parent.
-        var rosterSymbol = state.RosterSymbol;
-        if (rosterSymbol is not null)
+        var ctx = FindSelectionContext(state.RosterSymbol, forceId, selectionId);
+        if (ctx.Selection is not null && IsEntryCollective(ctx.Selection.SourceEntry))
         {
-            var forceSymbol = FindForceSymbolDeep(rosterSymbol, forceId);
-            if (forceSymbol is not null)
+            var parentNumber = ctx.ParentSelection?.SelectedCount ?? 0;
+            if (parentNumber > 0)
             {
-                var selSymbol = FindSelectionSymbolDeep(forceSymbol, selectionId);
-                if (selSymbol is not null && IsEntryCollective(selSymbol.SourceEntry))
+                var newNumber = selNode.Number - parentNumber;
+                if (newNumber > 0)
                 {
-                    var parentSel = FindParentSelection(force, selectionId);
-                    if (parentSel is not null && parentSel.Number > 0)
-                    {
-                        var newNumber = selNode.Number - parentSel.Number;
-                        if (newNumber > 0)
-                        {
-                            // Reduce count, scale children down proportionally.
-                            var newSelNode = ScaleChildSelections(selNode, selNode.Number, newNumber)
-                                .WithNumber(newNumber);
-                            var newRoster = roster.Replace(selNode, _ => newSelNode).WithUpdatedCostTotals();
-                            return state.ReplaceRoster(newRoster);
-                        }
-                        // Otherwise fall through to remove entirely.
-                    }
+                    var newSelNode = ScaleChildSelections(selNode, selNode.Number, newNumber)
+                        .WithNumber(newNumber);
+                    var newRoster = roster.Replace(selNode, _ => newSelNode).WithUpdatedCostTotals();
+                    return state.ReplaceRoster(newRoster);
                 }
             }
         }
@@ -1324,23 +1340,11 @@ public sealed class WhamRosterEngine
         var oldNumber = selNode.Number;
         var actualNumber = count;
 
-        // For collective entries, count is per-model: multiply by parent's number.
-        var rosterSymbol = state.RosterSymbol;
-        if (rosterSymbol is not null)
+        var ctx = FindSelectionContext(state.RosterSymbol, forceId, selectionId);
+        if (ctx.Selection is not null && IsEntryCollective(ctx.Selection.SourceEntry)
+            && ctx.ParentSelection is { } parentSel)
         {
-            var forceSymbol = FindForceSymbolDeep(rosterSymbol, forceId);
-            if (forceSymbol is not null)
-            {
-                var selSymbol = FindSelectionSymbolDeep(forceSymbol, selectionId);
-                if (selSymbol is not null && IsEntryCollective(selSymbol.SourceEntry))
-                {
-                    var parentSel = FindParentSelection(force, selectionId);
-                    if (parentSel is not null)
-                    {
-                        actualNumber = count * parentSel.Number;
-                    }
-                }
-            }
+            actualNumber = count * parentSel.SelectedCount;
         }
 
         // Scale children proportionally when the number changes.

--- a/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
@@ -304,14 +304,23 @@ public sealed class WhamRosterEngine
     /// categories, and recursively auto-selected child entries (those with min ≥ 1
     /// constraints on <c>selections</c> in <c>parent</c> scope).
     /// </summary>
+    /// <param name="entry">The entry symbol to create a selection for.</param>
+    /// <param name="sourceGroup">The group this entry was flattened from, if any.</param>
+    /// <param name="linkPrefix">
+    /// The accumulated link prefix from parent links above this entry.
+    /// Propagated to child entries so that their <c>entryId</c> values are correctly
+    /// prefixed with all link IDs in the hierarchy above them.
+    /// </param>
     private SelectionNode CreateSelectionWithAutoChildren(
         ISelectionEntryContainerSymbol entry,
-        ISelectionEntryGroupSymbol? sourceGroup)
+        ISelectionEntryGroupSymbol? sourceGroup,
+        string linkPrefix = "")
     {
-        var selectionNode = CreateSelectionNode(entry, sourceGroup);
+        var selectionNode = CreateSelectionNode(entry, sourceGroup, linkPrefix);
 
         // Auto-select child entries that have a minimum constraint ≥ 1.
-        var childEntries = EntryResolver.GetChildEntries(entry);
+        // Pass linkPrefix so GetChildEntries computes each child's LinkPrefix correctly.
+        var childEntries = EntryResolver.GetChildEntries(entry, linkPrefix);
 
         // Track which groups we've already auto-selected for (to avoid duplicates)
         var autoSelectedGroups = new HashSet<string>(StringComparer.Ordinal);
@@ -341,7 +350,8 @@ public sealed class WhamRosterEngine
             }
 
             // Create one child selection with Number set to the min count.
-            var childSelection = CreateSelectionWithAutoChildren(child.Symbol, child.SourceGroup);
+            // Use child.LinkPrefix so the child's entryId is correctly prefixed.
+            var childSelection = CreateSelectionWithAutoChildren(child.Symbol, child.SourceGroup, child.LinkPrefix);
             if (autoCount > 1)
             {
                 childSelection = childSelection.WithNumber(autoCount);
@@ -412,9 +422,16 @@ public sealed class WhamRosterEngine
     /// Resolves the backing <see cref="SelectionEntryNode"/> declaration through links,
     /// then populates costs and categories.
     /// </summary>
+    /// <param name="entry">The entry symbol to create a selection for.</param>
+    /// <param name="sourceGroup">The group this entry was flattened from, if any.</param>
+    /// <param name="linkPrefix">
+    /// The accumulated link prefix from parent links above this entry.
+    /// Prepended to the entry's own ID path to form the composite <c>entryId</c>.
+    /// </param>
     private static SelectionNode CreateSelectionNode(
         ISelectionEntryContainerSymbol entry,
-        ISelectionEntryGroupSymbol? sourceGroup)
+        ISelectionEntryGroupSymbol? sourceGroup,
+        string linkPrefix = "")
     {
         var entryDecl = ResolveToEntryDeclaration(entry)
             ?? throw new ArgumentException(
@@ -425,8 +442,11 @@ public sealed class WhamRosterEngine
         // For entry links, use "linkId::targetId" so the binder resolves
         // SourceEntryPath = [link, target] with SourceEntry = target.
         // For direct entries, use just the entry's ID.
-        var entryId = BuildEntryIdPath(entry);
-        var entryGroupId = sourceGroup?.Id;
+        // When a linkPrefix is present (from parent links), it is prepended.
+        var entryId = BuildEntryIdPath(entry, linkPrefix);
+        var entryGroupId = sourceGroup is null
+            ? null
+            : EntryResolver.JoinLinkPrefix(linkPrefix, sourceGroup.Id!);
 
         var selectionNode = NodeFactory.Selection(entryDecl, entryId, entryGroupId);
 
@@ -486,16 +506,25 @@ public sealed class WhamRosterEngine
     /// <c>"::"</c>-separated path format. For entry links, the path is
     /// <c>"linkId::targetId"</c> so that the binder produces
     /// <c>SourceEntryPath = [link, resolvedTarget]</c>. For direct entries,
-    /// returns just the entry's own ID.
+    /// returns just the entry's own ID. When a <paramref name="linkPrefix"/> is provided
+    /// (from parent links higher in the hierarchy), it is prepended to the built path.
     /// </summary>
-    private static string BuildEntryIdPath(ISelectionEntryContainerSymbol entry)
+    private static string BuildEntryIdPath(
+        ISelectionEntryContainerSymbol entry,
+        string linkPrefix = "")
     {
+        string myPath;
         if (entry.ReferencedEntry is { Id: { } targetId })
         {
             var linkId = entry.Id ?? "";
-            return $"{linkId}{EntryLinkIdSeparator}{targetId}";
+            myPath = $"{linkId}{EntryLinkIdSeparator}{targetId}";
         }
-        return entry.Id ?? "";
+        else
+        {
+            myPath = entry.Id ?? "";
+        }
+
+        return EntryResolver.JoinLinkPrefix(linkPrefix, myPath);
     }
 
     /// <summary>
@@ -645,6 +674,70 @@ public sealed class WhamRosterEngine
                 yield return c;
             }
         }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Collective entry helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Checks whether the resolved source entry for a symbol is collective.
+    /// Resolves through links to check the target entry.
+    /// </summary>
+    private static bool IsEntryCollective(ISelectionEntryContainerSymbol entry)
+    {
+        var resolved = EntryResolver.ResolveEntry(entry);
+        return resolved.IsCollective;
+    }
+
+    /// <summary>
+    /// Determines if an entry uses "number-increment" mode for repeated selections.
+    /// An entry is number-increment when ALL of its resolved children are either
+    /// collective or hidden. If any child is non-collective AND visible, the entry
+    /// uses "separate-node" mode instead.
+    /// </summary>
+    private static bool IsNumberIncrementEntry(ISelectionEntryContainerSymbol entry)
+    {
+        var resolved = EntryResolver.ResolveEntry(entry);
+        return AreAllChildrenCollectiveOrHidden(resolved);
+
+        static bool AreAllChildrenCollectiveOrHidden(ISelectionEntryContainerSymbol e)
+        {
+            foreach (var child in e.ChildSelectionEntries)
+            {
+                var childResolved = EntryResolver.ResolveEntry(child);
+                if (!childResolved.IsCollective && !childResolved.IsHidden)
+                    return false;
+                // Recursively check groups (their flattened children)
+                if (childResolved.ContainerKind == ContainerKind.SelectionGroup
+                    && !AreAllChildrenCollectiveOrHidden(childResolved))
+                    return false;
+            }
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Recursively scales all child selections proportionally when a parent's number changes.
+    /// Each child's new number = child.Number × newParentNumber / oldParentNumber.
+    /// </summary>
+    private static SelectionNode ScaleChildSelections(SelectionNode sel, int oldNumber, int newNumber)
+    {
+        if (oldNumber == newNumber || oldNumber == 0 || sel.Selections.Count == 0)
+            return sel;
+
+        var newChildren = new List<SelectionNode>(sel.Selections.Count);
+        foreach (var child in sel.Selections)
+        {
+            var scaledChildNumber = child.Number * newNumber / oldNumber;
+            if (scaledChildNumber < 1) scaledChildNumber = 1;
+            var scaledChild = child.WithNumber(scaledChildNumber);
+            // Recurse into grandchildren
+            scaledChild = ScaleChildSelections(scaledChild, child.Number, scaledChildNumber);
+            newChildren.Add(scaledChild);
+        }
+
+        return sel.WithSelections(sel.Selections.WithNodes(NodeList.Create(newChildren)));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -1022,7 +1115,7 @@ public sealed class WhamRosterEngine
         var available = EntryResolver.GetAvailableEntries(catalogue);
         var avail = EntryResolver.FindByEntryId(available, entryId);
 
-        var selectionNode = CreateSelectionWithAutoChildren(avail.Symbol, avail.SourceGroup);
+        var selectionNode = CreateSelectionWithAutoChildren(avail.Symbol, avail.SourceGroup, avail.LinkPrefix);
         var newForce = force.AddSelections(selectionNode);
         var newRoster = roster.Replace(force, _ => newForce).WithUpdatedCostTotals();
         var newState = state.ReplaceRoster(newRoster);
@@ -1058,10 +1151,69 @@ public sealed class WhamRosterEngine
                 $"Selection symbol '{parentSelectionId}' not found in force '{forceId}'.");
 
         var parentEntry = selectionSymbol.SourceEntry;
-        var childEntries = EntryResolver.GetChildEntries(parentEntry);
+
+        // Derive the link prefix accumulated up to the parent entry.
+        // The parent's entryId is a "linkId::targetId" (or "l1::l2::target") path;
+        // strip the last segment to recover the prefix used to reach parentEntry.
+        var parentEntryId = parentSel.EntryId ?? "";
+        var lastSep = parentEntryId.LastIndexOf("::", StringComparison.Ordinal);
+        var linkPrefix = lastSep >= 0 ? parentEntryId[..lastSep] : "";
+
+        var childEntries = EntryResolver.GetChildEntries(parentEntry, linkPrefix);
         var childAvail = EntryResolver.FindByEntryId(childEntries, entryId);
 
-        var childSelectionNode = CreateSelectionWithAutoChildren(childAvail.Symbol, childAvail.SourceGroup);
+        // isDuplicate: if the child entry has only collective/hidden children,
+        // repeated selectChildEntry increments the existing child's number.
+        if (IsNumberIncrementEntry(childAvail.Symbol))
+        {
+            foreach (var existingChild in parentSel.Selections)
+            {
+                if (existingChild.EntryId == entryId)
+                {
+                    // For collective entries, increment by parent's number (one per model).
+                    var increment = IsEntryCollective(childAvail.Symbol) ? parentSel.Number : 1;
+                    var newNumber = existingChild.Number + increment;
+                    var newSel = ScaleChildSelections(existingChild, existingChild.Number, newNumber)
+                        .WithNumber(newNumber);
+                    var newParentInc = parentSel.Replace(existingChild, _ => newSel);
+                    var newRosterInc = roster.Replace(parentSel, _ => newParentInc).WithUpdatedCostTotals();
+                    return new MutationResult(state.ReplaceRoster(newRosterInc))
+                    {
+                        SelectionId = newSel.Id,
+                        Selections = MutationResult.CollectSelectionMap(newSel)
+                    };
+                }
+            }
+        }
+
+        // If a child with this entryId was already auto-selected to satisfy a min constraint,
+        // return it as-is (no-op) instead of creating a duplicate.
+        var entryMin = GetMinSelectionCount(childAvail.Symbol);
+        if (entryMin >= 1)
+        {
+            foreach (var existingChild in parentSel.Selections)
+            {
+                if (existingChild.EntryId == entryId && existingChild.Number <= entryMin)
+                {
+                    return new MutationResult(state)
+                    {
+                        SelectionId = existingChild.Id,
+                        Selections = MutationResult.CollectSelectionMap(existingChild)
+                    };
+                }
+            }
+        }
+
+        var childSelectionNode = CreateSelectionWithAutoChildren(childAvail.Symbol, childAvail.SourceGroup, childAvail.LinkPrefix);
+
+        // Collective child: inherit parent's number.
+        if (IsEntryCollective(childAvail.Symbol) && parentSel.Number > 1)
+        {
+            var inheritedNumber = parentSel.Number;
+            childSelectionNode = ScaleChildSelections(childSelectionNode, childSelectionNode.Number, inheritedNumber)
+                .WithNumber(inheritedNumber);
+        }
+
         var newParent = parentSel.AddSelections(childSelectionNode);
         var newRoster = roster.Replace(parentSel, _ => newParent).WithUpdatedCostTotals();
         var newState = state.ReplaceRoster(newRoster);
@@ -1075,6 +1227,8 @@ public sealed class WhamRosterEngine
 
     /// <summary>
     /// Removes a selection by ID from a force (any nesting depth).
+    /// For collective entries, removes one per model (subtracts parent's number).
+    /// If the resulting count is zero or below, removes the node entirely.
     /// </summary>
     public RosterState DeselectSelectionById(
         RosterState state,
@@ -1084,8 +1238,37 @@ public sealed class WhamRosterEngine
         var roster = state.RosterRequired;
         var force = FindForceDeepRequired(roster, forceId);
         var selNode = FindSelectionDeepRequired(force, forceId, selectionId);
-        var newRoster = roster.Remove(selNode).WithUpdatedCostTotals();
-        return state.ReplaceRoster(newRoster);
+
+        // Check if this is a collective entry with a parent.
+        var rosterSymbol = state.RosterSymbol;
+        if (rosterSymbol is not null)
+        {
+            var forceSymbol = FindForceSymbolDeep(rosterSymbol, forceId);
+            if (forceSymbol is not null)
+            {
+                var selSymbol = FindSelectionSymbolDeep(forceSymbol, selectionId);
+                if (selSymbol is not null && IsEntryCollective(selSymbol.SourceEntry))
+                {
+                    var parentSel = FindParentSelection(force, selectionId);
+                    if (parentSel is not null && parentSel.Number > 0)
+                    {
+                        var newNumber = selNode.Number - parentSel.Number;
+                        if (newNumber > 0)
+                        {
+                            // Reduce count, scale children down proportionally.
+                            var newSelNode = ScaleChildSelections(selNode, selNode.Number, newNumber)
+                                .WithNumber(newNumber);
+                            var newRoster = roster.Replace(selNode, _ => newSelNode).WithUpdatedCostTotals();
+                            return state.ReplaceRoster(newRoster);
+                        }
+                        // Otherwise fall through to remove entirely.
+                    }
+                }
+            }
+        }
+
+        var removedRoster = roster.Remove(selNode).WithUpdatedCostTotals();
+        return state.ReplaceRoster(removedRoster);
     }
 
     /// <summary>
@@ -1124,7 +1307,9 @@ public sealed class WhamRosterEngine
     }
 
     /// <summary>
-    /// Sets the selection count by ID.
+    /// Sets the selection count by ID. For collective entries, the count is
+    /// per-model (multiplied by the parent's number). When any selection's
+    /// number changes, all children scale proportionally.
     /// </summary>
     public RosterState SetSelectionCountById(
         RosterState state,
@@ -1136,7 +1321,31 @@ public sealed class WhamRosterEngine
         var force = FindForceDeepRequired(roster, forceId);
         var selNode = FindSelectionDeepRequired(force, forceId, selectionId);
 
-        var newSelNode = selNode.WithNumber(count);
+        var oldNumber = selNode.Number;
+        var actualNumber = count;
+
+        // For collective entries, count is per-model: multiply by parent's number.
+        var rosterSymbol = state.RosterSymbol;
+        if (rosterSymbol is not null)
+        {
+            var forceSymbol = FindForceSymbolDeep(rosterSymbol, forceId);
+            if (forceSymbol is not null)
+            {
+                var selSymbol = FindSelectionSymbolDeep(forceSymbol, selectionId);
+                if (selSymbol is not null && IsEntryCollective(selSymbol.SourceEntry))
+                {
+                    var parentSel = FindParentSelection(force, selectionId);
+                    if (parentSel is not null)
+                    {
+                        actualNumber = count * parentSel.Number;
+                    }
+                }
+            }
+        }
+
+        // Scale children proportionally when the number changes.
+        var newSelNode = ScaleChildSelections(selNode, oldNumber, actualNumber)
+            .WithNumber(actualNumber);
         var newRoster = roster.Replace(selNode, _ => newSelNode).WithUpdatedCostTotals();
         return state.ReplaceRoster(newRoster);
     }

--- a/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
@@ -1038,8 +1038,9 @@ public sealed class WhamRosterEngine
         var newForce = roster.Forces[^1];
         var forceId = newForce.Id!;
 
-        // Auto-select root entries with min constraints
-        state = AutoSelectRootEntries(state, roster.Forces.Count - 1, catalogue);
+        // Auto-select root entries with min constraints, filtered by force categories
+        var forceCategoryIds = GetForceCategoryIds(forceEntry);
+        state = AutoSelectRootEntries(state, roster.Forces.Count - 1, catalogue, forceCategoryIds);
 
         // Build selections map from the force's final state
         var finalForce = state.RosterRequired.Forces[^1];
@@ -1425,7 +1426,8 @@ public sealed class WhamRosterEngine
     private RosterState AutoSelectRootEntries(
         RosterState state,
         int forceIndex,
-        ICatalogueSymbol catalogue)
+        ICatalogueSymbol catalogue,
+        HashSet<string>? forceCategoryIds)
     {
         var available = EntryResolver.GetAvailableEntries(catalogue);
         var autoSelectedGroups = new HashSet<string>(StringComparer.Ordinal);
@@ -1435,6 +1437,10 @@ public sealed class WhamRosterEngine
             var effectiveEntry = avail.Symbol.IsReference
                 ? avail.Symbol.ReferencedEntry ?? avail.Symbol
                 : avail.Symbol;
+
+            // Skip entries whose primary category is not in the force's categories.
+            if (forceCategoryIds is not null && !EntryMatchesForceCategories(effectiveEntry, forceCategoryIds))
+                continue;
 
             var minCount = GetMinAutoSelectCount(effectiveEntry);
 
@@ -1460,6 +1466,42 @@ public sealed class WhamRosterEngine
         }
 
         return state;
+    }
+
+    /// <summary>
+    /// Collects the set of category entry IDs declared on a force entry.
+    /// Returns null if the force has no categories (meaning no filtering needed for
+    /// uncategorized entries, but categorized entries should NOT auto-select).
+    /// </summary>
+    private static HashSet<string>? GetForceCategoryIds(IForceEntrySymbol forceEntry)
+    {
+        if (forceEntry.Categories.IsEmpty)
+            return new HashSet<string>(StringComparer.Ordinal);
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var cat in forceEntry.Categories)
+        {
+            var target = cat.ReferencedEntry ?? cat;
+            if (target.Id is { } id)
+                ids.Add(id);
+        }
+        return ids;
+    }
+
+    /// <summary>
+    /// Checks if a root entry's primary category is among the force's declared categories.
+    /// Entries without a primary category are allowed in any force.
+    /// When the force has no categories, only uncategorized entries are allowed.
+    /// </summary>
+    private static bool EntryMatchesForceCategories(
+        ISelectionEntryContainerSymbol entry, HashSet<string> forceCategoryIds)
+    {
+        var primaryCat = entry.PrimaryCategory;
+        if (primaryCat is null)
+            return true; // uncategorized entries are available everywhere
+
+        var catTarget = primaryCat.ReferencedEntry ?? primaryCat;
+        return catTarget.Id is { } catId && forceCategoryIds.Contains(catId);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Update battlescribe-spec submodule to latest main and implement conformance fixes including the full collective feature.

## Test Results

**351/353 conformance tests passing** (up from 322/353 before this branch)

### Implemented
- double to decimal migration for TestKit Protocol types
- Entry-id prefix propagation for link chains (9 entry-id specs)
- Roster name from test context
- Multiple additive repeats
- includeChildForces scope traversal
- SEG constraint evaluation
- shared flag for constraints/conditions/repeats
- Selection ordering (effective name + natural sort)
- PrimaryCatalogue scope fix in BindFilterEntrySymbol
- **Collective feature** (all 18 collective specs passing):
  - IsCollective surfaced on ISelectionEntryContainerSymbol
  - Per-model SetSelectionCount for collective entries
  - Recursive child number propagation
  - isDuplicate mode for entries with only collective/hidden children
  - Collective child inherits parent number
  - Per-model deselect
  - Per-model constraint evaluation in ConstraintEvaluator

### Remaining 2 failures
- scope-child-id-filter: genuine ordering conflict between BS/NR defaults (needs wham engine override in spec)
- protocol-kitchen-sink: hidden diagnostic generation + force selection count after deselect (pre-existing)