### PR TITLE
fix: address PR #302 review feedback, update spec submodule

### DIFF
--- a/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
@@ -70,9 +70,12 @@ internal static class SelectionOrdering
             if (a.EffectiveSourceEntry.Name != a.SourceEntry?.Name
                 || b.EffectiveSourceEntry.Name != b.SourceEntry?.Name)
             {
-                return NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
+                cmp = NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
+                if (cmp != 0) return cmp;
             }
-            return 0;
+            // Stable tiebreaker: compare by EntryId to ensure deterministic ordering
+            // when effective names match (ImmutableArray.Sort is unstable).
+            return string.Compare(a.EntryId, b.EntryId, StringComparison.Ordinal);
         }
     }
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
@@ -31,7 +31,8 @@ internal static class SelectionOrdering
                 categoryOrder[catEntryId] = i;
         }
 
-        return force.Selections.Sort(new ForceSelectionComparer(categoryOrder));
+        // Use stable LINQ sort to preserve insertion order (FIFO) for equal elements.
+        return [.. force.Selections.OrderBy(x => x, new ForceSelectionComparer(categoryOrder))];
     }
 
     /// <summary>
@@ -41,7 +42,8 @@ internal static class SelectionOrdering
     /// </summary>
     internal static ImmutableArray<ISelectionSymbol> GetSortedChildSelections(ISelectionSymbol parent)
     {
-        return parent.Selections.Sort(SelectionNameComparer.Instance);
+        // Use stable LINQ sort to preserve insertion order (FIFO) for equal elements.
+        return [.. parent.Selections.OrderBy(x => x, SelectionNameComparer.Instance)];
     }
 
     /// <summary>
@@ -55,6 +57,7 @@ internal static class SelectionOrdering
     /// <summary>
     /// Compares selections by effective name (natural sort), with original entry name as tiebreaker
     /// only when modifiers have changed at least one name.
+    /// Returns 0 for equal names to preserve insertion order (FIFO) when used with a stable sort.
     /// </summary>
     internal sealed class SelectionNameComparer : IComparer<ISelectionSymbol>
     {
@@ -73,9 +76,8 @@ internal static class SelectionOrdering
                 cmp = NaturalSort.Compare(a.SourceEntry?.Name ?? a.Name, b.SourceEntry?.Name ?? b.Name);
                 if (cmp != 0) return cmp;
             }
-            // Stable tiebreaker: compare by EntryId to ensure deterministic ordering
-            // when effective names match (ImmutableArray.Sort is unstable).
-            return string.Compare(a.EntryId, b.EntryId, StringComparison.Ordinal);
+            // Return 0 for equal names — stable sort preserves insertion order (FIFO).
+            return 0;
         }
     }
 

--- a/src/WarHub.ArmouryModel.RosterEngine/EntryResolver.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/EntryResolver.cs
@@ -238,9 +238,12 @@ public static class EntryResolver
     /// <summary>
     /// Joins a link prefix with an ID, using the "::" separator.
     /// When the prefix is empty, returns the ID directly.
+    /// When the ID is null or empty, returns the prefix unchanged (no-op).
     /// </summary>
     internal static string JoinLinkPrefix(string prefix, string id)
-        => string.IsNullOrEmpty(prefix) ? id : $"{prefix}::{id}";
+        => string.IsNullOrEmpty(id) ? prefix
+        : string.IsNullOrEmpty(prefix) ? id
+        : $"{prefix}::{id}";
 
     /// <summary>
     /// Follows the <see cref="ISelectionEntryContainerSymbol.ReferencedEntry"/> chain

--- a/src/WarHub.ArmouryModel.RosterEngine/EntryResolver.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/EntryResolver.cs
@@ -116,7 +116,7 @@ public static class EntryResolver
 
         // If this entry is a link, children accumulate its ID into the prefix.
         var childPrefix = entry.ReferencedEntry is not null
-            ? JoinLinkPrefix(contextLinkPrefix, entry.Id!)
+            ? JoinLinkPrefix(contextLinkPrefix, entry.Id ?? "")
             : contextLinkPrefix;
 
         foreach (var child in effective.ChildSelectionEntries)
@@ -170,7 +170,7 @@ public static class EntryResolver
             // The target is a group — compute the prefix for the group's children.
             // If this entry is a link to the group, the link's ID is added to the prefix.
             var groupPrefix = entry.ReferencedEntry is not null
-                ? JoinLinkPrefix(parentLinkPrefix, entry.Id!)
+                ? JoinLinkPrefix(parentLinkPrefix, entry.Id ?? "")
                 : parentLinkPrefix;
             FlattenGroup(group, result, visited: null, groupLinkPrefix: groupPrefix);
         }
@@ -219,7 +219,7 @@ public static class EntryResolver
             {
                 // Nested group: if the child is a link to the group, extend the prefix.
                 var nestedPrefix = child.ReferencedEntry is not null
-                    ? JoinLinkPrefix(groupLinkPrefix, child.Id!)
+                    ? JoinLinkPrefix(groupLinkPrefix, child.Id ?? "")
                     : groupLinkPrefix;
                 FlattenGroup(childGroup, result, visited, nestedPrefix);
             }

--- a/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
@@ -446,7 +446,7 @@ public sealed class WhamRosterEngine
         var entryId = BuildEntryIdPath(entry, linkPrefix);
         var entryGroupId = sourceGroup is null
             ? null
-            : EntryResolver.JoinLinkPrefix(linkPrefix, sourceGroup.Id!);
+            : EntryResolver.JoinLinkPrefix(linkPrefix, sourceGroup.Id ?? "");
 
         var selectionNode = NodeFactory.Selection(entryDecl, entryId, entryGroupId);
 
@@ -1192,11 +1192,15 @@ public sealed class WhamRosterEngine
 
         // isDuplicate: if the child entry has only collective/hidden children,
         // repeated selectChildEntry increments the existing child's number.
+        // Use the computed composite entryId for comparison, as stored selections
+        // use the composite form (e.g., "linkId::targetId") while the input entryId
+        // may be in raw form.
+        var compositeEntryId = EntryResolver.ComputeCompositeEntryId(childAvail);
         if (IsNumberIncrementEntry(childAvail.Symbol))
         {
             foreach (var existingChild in parentSel.Selections)
             {
-                if (existingChild.EntryId == entryId)
+                if (existingChild.EntryId == compositeEntryId)
                 {
                     // For collective entries, increment by parent's number (one per model).
                     var increment = IsEntryCollective(childAvail.Symbol) ? parentSel.Number : 1;
@@ -1221,7 +1225,7 @@ public sealed class WhamRosterEngine
         {
             foreach (var existingChild in parentSel.Selections)
             {
-                if (existingChild.EntryId == entryId && existingChild.Number <= entryMin)
+                if (existingChild.EntryId == compositeEntryId && existingChild.Number <= entryMin)
                 {
                     return new MutationResult(state)
                     {
@@ -1470,7 +1474,7 @@ public sealed class WhamRosterEngine
 
     /// <summary>
     /// Collects the set of category entry IDs declared on a force entry.
-    /// Returns null if the force has no categories (meaning no filtering needed for
+    /// Returns an empty set if the force has no categories (meaning no filtering needed for
     /// uncategorized entries, but categorized entries should NOT auto-select).
     /// </summary>
     private static HashSet<string>? GetForceCategoryIds(IForceEntrySymbol forceEntry)

--- a/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
@@ -444,9 +444,9 @@ public sealed class WhamRosterEngine
         // For direct entries, use just the entry's ID.
         // When a linkPrefix is present (from parent links), it is prepended.
         var entryId = BuildEntryIdPath(entry, linkPrefix);
-        var entryGroupId = sourceGroup is null
-            ? null
-            : EntryResolver.JoinLinkPrefix(linkPrefix, sourceGroup.Id ?? "");
+        var entryGroupId = sourceGroup?.Id is { Length: > 0 }
+            ? EntryResolver.JoinLinkPrefix(linkPrefix, sourceGroup.Id)
+            : null;
 
         var selectionNode = NodeFactory.Selection(entryDecl, entryId, entryGroupId);
 
@@ -513,18 +513,14 @@ public sealed class WhamRosterEngine
         ISelectionEntryContainerSymbol entry,
         string linkPrefix = "")
     {
-        string myPath;
         if (entry.ReferencedEntry is { Id: { } targetId })
         {
-            var linkId = entry.Id ?? "";
-            myPath = $"{linkId}{EntryLinkIdSeparator}{targetId}";
+            // For links: prefix::linkId::targetId (skipping empty segments)
+            return EntryResolver.JoinLinkPrefix(
+                EntryResolver.JoinLinkPrefix(linkPrefix, entry.Id ?? ""),
+                targetId);
         }
-        else
-        {
-            myPath = entry.Id ?? "";
-        }
-
-        return EntryResolver.JoinLinkPrefix(linkPrefix, myPath);
+        return EntryResolver.JoinLinkPrefix(linkPrefix, entry.Id ?? "");
     }
 
     /// <summary>
@@ -1431,7 +1427,7 @@ public sealed class WhamRosterEngine
         RosterState state,
         int forceIndex,
         ICatalogueSymbol catalogue,
-        HashSet<string>? forceCategoryIds)
+        HashSet<string> forceCategoryIds)
     {
         var available = EntryResolver.GetAvailableEntries(catalogue);
         var autoSelectedGroups = new HashSet<string>(StringComparer.Ordinal);
@@ -1477,7 +1473,7 @@ public sealed class WhamRosterEngine
     /// Returns an empty set if the force has no categories (meaning no filtering needed for
     /// uncategorized entries, but categorized entries should NOT auto-select).
     /// </summary>
-    private static HashSet<string>? GetForceCategoryIds(IForceEntrySymbol forceEntry)
+    private static HashSet<string> GetForceCategoryIds(IForceEntrySymbol forceEntry)
     {
         if (forceEntry.Categories.IsEmpty)
             return new HashSet<string>(StringComparer.Ordinal);


### PR DESCRIPTION
Addresses review feedback from PR #302, updates spec submodule, and fixes edge cases.

## Changes

### Null/empty ID edge cases (review threads 1-3)
- `JoinLinkPrefix` now treats empty `id` as a no-op — prevents dangling `"::"` segments
- `BuildEntryIdPath` refactored to use `JoinLinkPrefix` for link path construction, matching `ComputeCompositeEntryId` exactly
- `entryGroupId` passes `null` when `sourceGroup.Id` is null/empty

### Selection ordering stability (review thread 5)
- Switched from unstable `ImmutableArray.Sort` to stable LINQ `OrderBy`
- Removed `EntryId` tiebreaker — equal-name selections preserve FIFO insertion order

### Other improvements
- `GetForceCategoryIds` return type changed from `HashSet<string>?` to `HashSet<string>` (never returns null)

### Spec submodule update
- Updated `lib/battlescribe-spec` to latest `main` (aa18776) which includes fix for contradictory ordering defaults (WarHub/battlescribe-spec#220)
- wham no longer needs any engine-specific overrides

All 353 conformance tests pass.