### PR TITLE
feat: add wham-spec-sync project skill

### DIFF
--- a/.agents/skills/wham-spec-sync/SKILL.md
+++ b/.agents/skills/wham-spec-sync/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: wham-spec-sync
+description: >
+  Sync wham's lib/battlescribe-spec submodule to latest main and make wham conform
+  to new specs. Full lifecycle: evaluate changes, update submodule, fix API breaks,
+  run conformance tests, triage and fix failures, handle spec contradictions (with
+  upstream issues/PRs), create draft PR, iterate until CI green.
+  Use when user says "update spec", "sync conformance", "new battlescribe-spec changes",
+  "update the submodule", or "spec PR".
+---
+
+# wham-spec-sync
+
+Sync `lib/battlescribe-spec` to latest `main` and drive wham to full conformance.
+Covers the full lifecycle from evaluation to a CI-green PR ready to merge.
+
+## When to Use
+
+- "Update spec", "sync the submodule", "new battlescribe-spec changes"
+- "Run conformance tests" after a spec repo update
+- "Spec PR", "update wham to latest spec"
+- Before or after a battlescribe-spec PR merges upstream
+
+## Prerequisites
+
+- `git submodule update --init` must have been run at least once
+- `gh` CLI authenticated (`gh auth status`)
+- Working `dotnet` SDK (build and test)
+- Apply **gh-cli** skill guardrails for all PR/issue body operations
+
+## Phase 0 — Evaluate Changes
+
+Before touching anything, understand what changed:
+
+```bash
+# See what commits are incoming
+git -C lib/battlescribe-spec fetch origin main
+git -C lib/battlescribe-spec log HEAD..origin/main --oneline
+
+# List changed spec YAML files
+git -C lib/battlescribe-spec diff HEAD origin/main --name-only -- specs/
+```
+
+Read changed YAML files to classify changes:
+- **New specs**: new feature or behavior being tested → likely need engine implementation
+- **Modified specs**: adjusted expectations → may be API renames or behavior fixes
+- **Removed specs**: deleted or folded into another spec → remove associated `[Fact(Skip=...)]` annotations
+- **TestKit/API changes**: modified C# files in `src/BattleScribeSpec.TestKit/` → check for breaks
+
+**Present a summary to the user** before proceeding. Flag anything that looks like a large
+new feature (e.g. new spec category) that warrants discussion.
+
+## Phase 1 — Update Submodule
+
+```bash
+git -C lib/battlescribe-spec checkout origin/main
+# Verify the new HEAD
+git -C lib/battlescribe-spec log -1 --oneline
+```
+
+Then create a branch off the current feature branch and commit the submodule bump:
+
+```bash
+git checkout -b spec-update/{short-description}
+git add lib/battlescribe-spec
+git commit -m "chore: update battlescribe-spec submodule to {new-sha-short}"
+```
+
+## Phase 2 — Fix API Breaks
+
+Build first to surface compilation errors before running tests:
+
+```bash
+dotnet build
+```
+
+Common break patterns are documented in
+[references/api-breaks.md](references/api-breaks.md). Fix all compilation errors
+before proceeding — test output is misleading when the project doesn't compile.
+
+## Phase 3 — Run Conformance Tests + Triage
+
+```bash
+dotnet test tests/WarHub.ArmouryModel.RosterEngine.Tests/
+```
+
+Collect failing test IDs and group them by **spec category** (the directory under
+`lib/battlescribe-spec/specs/`). Within each category, sort by likely cause:
+
+| Cause | Signal |
+|---|---|
+| API rename / compile artifact | Failure message mentions missing member or cast |
+| New spec (unimplemented feature) | Multiple failures in a new spec category |
+| Regression from submodule bump | Spec previously passing now fails |
+| Spec contradiction | Two specs conflict; wham can't satisfy both defaults |
+
+Run a single spec to get a detailed error:
+```bash
+dotnet test tests/WarHub.ArmouryModel.RosterEngine.Tests/ --filter "DisplayName~{spec-id}"
+```
+
+## Phase 4 — Fix Implementation Issues
+
+Work failures category by category, simplest first. Wham-specific patterns:
+
+- **Selection ordering**: wham sorts by effective (post-modifier) name — see `WhamRosterEngine.cs`
+- **Entry-id prefix**: link selections use `"linkId::targetId"` format; propagation via `JoinPrefix`
+- **Collective semantics**: per-model multiply/divide; see `ConstraintEvaluator.cs` and `WhamRosterEngine.cs`
+- **Scope traversal**: `ModifierEvaluator` scope methods mirror the `descendIntoSelections/Forces` flags
+- **StateMapper**: reads only `ISymbol` public API — no `SourceNode` access; `Name` is non-nullable
+
+Commit after each logical fix group. Run full suite frequently to catch regressions.
+
+## Phase 5 — Handle Spec Contradictions
+
+When two specs conflict such that wham cannot satisfy both defaults, see
+[references/spec-contradictions.md](references/spec-contradictions.md) for the
+decision flow: add a temporary wham engine override, file an upstream issue,
+open a fix PR, then remove the override once the upstream PR merges and the
+submodule is bumped again.
+
+## Phase 6 — PR Lifecycle
+
+Once all (or all addressable) conformance tests pass:
+
+```bash
+# Push the branch
+git push -u origin HEAD
+
+# Open draft PR targeting the current feature branch
+gh pr create --draft \
+  --base {current-feature-branch} \
+  --title "chore: update battlescribe-spec to {date/version}" \
+  --body "..."
+```
+
+PR body should include:
+- New submodule SHA and a link to the diff in battlescribe-spec
+- Summary of spec changes (new specs, modified specs, removed specs)
+- List of implementation changes in wham
+- Any outstanding wham engine overrides and their upstream tracking issues
+
+Iterate: fix → test → commit → push until CI is green.
+Mark ready when all checks pass:
+
+```bash
+gh pr ready {number}
+```
+
+**Do not merge** — use the **finish-pr** skill for the final merge step.
+
+## Decision Quick-Reference
+
+| Situation | Action |
+|---|---|
+| New spec category (e.g. `collective/`) | Implement the feature; it's unlikely to be a bug |
+| Spec that was `KnownUndefinedBehavior` now promoted | Remove `Skip` annotation; fix if failing |
+| Two specs conflict on same behavior | See spec-contradictions.md; add wham override + file upstream issue |
+| Spec removed upstream | Delete associated `[Fact(Skip=...)]` in `ConformanceTests.cs` |
+| TestKit API renamed | Fix call sites in `ConformanceTests.cs`, `SpecRosterEngineAdapter.cs`, `StateMapper.cs` |
+| Conformance test passes but CI fails | Check non-conformance test projects: `dotnet test` |
+| Upstream battlescribe-spec PR just merged | Re-run Phase 0 to evaluate, then Phase 1 to bump submodule |
+
+## Reference Files
+
+- [references/api-breaks.md](references/api-breaks.md) — Recurring API break patterns from past updates
+- [references/spec-contradictions.md](references/spec-contradictions.md) — Detecting, overriding, and fixing spec self-contradictions

--- a/.agents/skills/wham-spec-sync/references/api-breaks.md
+++ b/.agents/skills/wham-spec-sync/references/api-breaks.md
@@ -1,0 +1,71 @@
+# API Break Patterns
+
+Recurring break patterns when bumping `lib/battlescribe-spec`. Check these first
+after a submodule update causes compilation errors.
+
+## Namespace Renames
+
+| Old | New | Files affected |
+|---|---|---|
+| `BattleScribeSpec` | `BattleScribeSpec.Roster` | `ConformanceTests.cs`, `SpecRosterEngineAdapter.cs`, `StateMapper.cs` |
+
+## Class / Type Renames
+
+| Old | New | Files affected |
+|---|---|---|
+| `SpecRunner` | `RosterRunner` | `ConformanceTests.cs` |
+
+Search for the old name with grep; there should be no survivors after the fix.
+
+## Removed `KnownUndefinedBehavior` Entries
+
+Specs that were previously annotated as undefined behavior get promoted to
+regular specs when the spec repo adds a clear expectation. When this happens:
+
+1. The test that had `[Fact(Skip = "KnownUndefinedBehavior: ...")]` will now
+   **compile but the Skip is gone** — or the spec file itself is deleted/merged.
+2. Remove the `Skip` annotation (or the entire `[Fact]` override if the spec was deleted).
+3. Run the test — it likely passes once the `Skip` is removed; if not, there is
+   a real implementation gap.
+
+## New Protocol Field Types
+
+When the spec introduces a new field or changes a field type on a `Protocol*`
+record (e.g. `double` → `decimal` for cost/limit values), `StateMapper.cs` will
+fail to compile. Update the relevant mapping expression to match the new type.
+
+Pattern to check in `StateMapper.cs`:
+```csharp
+// Before (double)
+Value = cost.Value,  // double
+// After (decimal)
+Value = (double)cost.Value,  // if Protocol type kept double
+// OR
+Value = cost.Value,  // if Protocol type changed to decimal too
+```
+
+Verify by checking the Protocol record definition in
+`lib/battlescribe-spec/src/BattleScribeSpec.TestKit/Protocol/`.
+
+## New Protocol Types (New Features)
+
+When a new spec category appears (e.g. `specs/collective/`) and the TestKit adds
+new `Protocol*` types, `StateMapper` must be extended to populate them.
+`SpecRosterEngineAdapter` may also need changes to wire the new feature into
+`IRosterEngine` calls.
+
+Steps:
+1. Check which new `Protocol*` types were added in `BattleScribeSpec.TestKit/Protocol/`
+2. Find where the spec expects them to appear in `IRosterState`
+3. Add population logic in `StateMapper.cs`
+
+## ConformanceTests.cs Registration
+
+Engine name must remain `"wham"` — changing it invalidates all `engines.wham:` overrides:
+
+```csharp
+// ConformanceTests.cs
+runner.RegisterEngine("wham", new WhamRosterEngineAdapter(...));
+```
+
+Do not rename or add aliases.

--- a/.agents/skills/wham-spec-sync/references/spec-contradictions.md
+++ b/.agents/skills/wham-spec-sync/references/spec-contradictions.md
@@ -1,0 +1,109 @@
+# Spec Contradictions
+
+How to detect, work around, and resolve self-contradictions in `battlescribe-spec`.
+
+## Detecting a Contradiction
+
+A spec contradiction is when two specs have conflicting **default** expectations
+for the same engine behavior, making it impossible for a new engine to satisfy both.
+
+Signs:
+- One spec fails with `expected X but got Y`; another spec expects `Y` for the same behavior
+- Existing wham overrides flip exactly those two specs against each other
+- BattleScribe and NewRecruit have engine-specific overrides going in opposite directions
+
+Investigation steps:
+1. Identify the failing spec and its expected value
+2. Search other specs in the same category for the same behavior:
+   ```bash
+   grep -r "the-behavior-keyword" lib/battlescribe-spec/specs/ --include="*.yaml" -l
+   ```
+3. Check if the default expectations are internally inconsistent across specs
+
+## Wham Engine Override Format
+
+Add a `engines.wham:` section to the spec YAML with the wham-specific expectation.
+Only override the fields that differ; everything else inherits from the spec default.
+
+```yaml
+# In lib/battlescribe-spec/specs/{category}/{id}.yaml
+engines:
+  wham:
+    steps:
+      - step: 3
+        force:
+          - selection:
+              - name: Active Watcher  # wham effective-name sort order
+              - name: Target Unit
+```
+
+The `errors:` and `errorsContain:` keys can also be overridden:
+```yaml
+engines:
+  wham:
+    errors:
+      - on: 'ForceType forceId'
+        from: 'entryId/constraintId'
+```
+
+Error format for wham: `on='ownerType ownerEntryId', from='entryId/constraintId'`
+(`errors:` = exact set match; `errorsContain:` = subset match)
+
+**Never add wham overrides to the battlescribe-spec repo** — they must be in a fork/PR
+or the spec repo itself if the fix belongs there.
+
+## When to Override vs When to Fix Upstream
+
+| Situation | Action |
+|---|---|
+| Wham has a genuine implementation bug | Fix wham, do not add override |
+| Spec default matches BattleScribe quirk (not "correct" behavior) | Add wham override that reflects correct behavior; file upstream issue |
+| Two spec defaults conflict (wham can't satisfy both) | Add temporary wham override; file upstream issue + PR to fix the contradiction |
+| Spec documents explicitly undefined behavior | Check if `KnownUndefinedBehavior` is still appropriate or was resolved |
+
+## Filing an Upstream Issue in battlescribe-spec
+
+Repository: `WarHub/battlescribe-spec`
+
+Issue should include:
+- The two (or more) conflicting spec IDs
+- The exact conflicting default values
+- Why a new engine cannot satisfy both
+- What behavior wham implements and why it's correct
+
+```bash
+gh issue create --repo WarHub/battlescribe-spec \
+  --title "Spec contradiction: {spec-a} vs {spec-b} on {behavior}" \
+  --body-file /tmp/issue-body.md
+```
+
+## Opening a Fix PR in battlescribe-spec
+
+1. Fork (or push to a branch if you have write access)
+2. Edit the spec YAML — move one spec's default to match the intended behavior,
+   add engine-specific overrides for BattleScribe/NewRecruit where they differ
+3. Open a PR referencing the tracking issue
+
+```bash
+gh pr create --repo WarHub/battlescribe-spec \
+  --title "Fix: align {spec-id} default to effective-name sort order" \
+  --body "Fixes #{issue-number}. ..."
+```
+
+## After Upstream Merge: Removing Wham Overrides
+
+Once the fix PR merges into battlescribe-spec `main`:
+
+1. Bump the submodule (Phase 1 of the skill)
+2. Delete the wham-specific override blocks from the affected spec YAMLs
+   (they now live in `lib/battlescribe-spec/` which is read-only — if overrides
+   were in a fork branch, that branch is no longer needed)
+3. Run conformance tests to confirm no regressions
+4. Update the PR body to note the upstream fix
+
+## Known Historical Overrides
+
+| Spec ID | Behavior | Resolution |
+|---|---|---|
+| `scope-child-id-filter` | Selection sort order (effective vs original name) | Fixed upstream in battlescribe-spec PR #220; wham override removed |
+| `scope-primary-catalogue` | Selection sort order | Consistent with effective-name sort; no override needed |


### PR DESCRIPTION
Adds `.agents/skills/wham-spec-sync/` — a project skill that codifies the recurring `lib/battlescribe-spec` submodule update workflow.

## What's in the skill

**`SKILL.md`** — full lifecycle workflow:

- **Phase 0 — Evaluate**: diff submodule HEAD vs `origin/main`, read changed spec YAMLs, classify changes before touching anything
- **Phase 1 — Update**: bump submodule, branch off current feature branch
- **Phase 2 — Fix API breaks**: build first, fix compilation before running tests
- **Phase 3 — Conformance tests + triage**: categorize failures by cause (API artifact, new feature, regression, contradiction)
- **Phase 4 — Fix implementation**: wham-specific patterns (collective, entry-id prefix, scope traversal, StateMapper)
- **Phase 5 — Spec contradictions**: engine override format, upstream issues/PRs
- **Phase 6 — PR lifecycle**: draft PR → iterate → CI green → ready (hands off to `finish-pr` for merge)

**`references/api-breaks.md`** — recurring break patterns from past updates: namespace renames, class renames, removed `KnownUndefinedBehavior`, protocol type changes

**`references/spec-contradictions.md`** — detecting self-contradictions, wham `engines.wham:` override format, filing upstream issues/PRs in `WarHub/battlescribe-spec`, removing overrides after upstream fix

## Motivation

The spec-sync workflow has spanned several multi-session efforts. The steps are wham-specific enough (engine override format, conformance test filter syntax, `StateMapper` patterns, `JoinPrefix` entry-id semantics) that an agentic skill significantly reduces ramp-up time on the next update.