### PR TITLE
chore: update battlescribe-spec to e40d06c, remove zero-fill, fix cost scaling and evaluator correctness

### DIFF
--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ErrorCode.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ErrorCode.cs
@@ -24,4 +24,5 @@ internal enum ErrorCode
     WRN_MaxForceCountViolation = 105,
     WRN_MinCategoryCountViolation = 106,
     WRN_MaxCategoryCountViolation = 107,
+    WRN_CostRepeatCycle = 108,
 }

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ErrorFacts.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Diagnostics/ErrorFacts.cs
@@ -82,6 +82,8 @@ internal static partial class ErrorFacts
                 "Minimum category count not met: on='{0}', from='{1}', min={2}, actual={3}.",
             ErrorCode.WRN_MaxCategoryCountViolation =>
                 "Maximum category count exceeded: on='{0}', from='{1}', max={2}, actual={3}.",
+            ErrorCode.WRN_CostRepeatCycle =>
+                "Cost-field repeat cycle detected: entry '{2}' has a modifier repeat that transitively depends on its own cost. The looping modifier is not applied.",
             _ => code.ToString(),
         };
 

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/SelectionOrdering.cs
@@ -55,6 +55,32 @@ internal static class SelectionOrdering
     }
 
     /// <summary>
+    /// Returns child forces sorted by definition order from the parent force entry.
+    /// Forces whose entry is not found in the definition list are placed last, in their original insertion order.
+    /// </summary>
+    internal static ImmutableArray<IForceSymbol> GetSortedChildForces(IForceSymbol force)
+    {
+        var children = force.Forces;
+        if (children.Length <= 1)
+            return children;
+
+        var definedChildForces = force.EffectiveSourceEntry.ChildForces;
+        if (definedChildForces.Length == 0)
+            return children;
+
+        var definitionOrder = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (int i = 0; i < definedChildForces.Length; i++)
+        {
+            if (definedChildForces[i].Id is { } entryId)
+                definitionOrder[entryId] = i;
+        }
+
+        // Stable sort: forces in definition order first, then any unrecognized ones.
+        return [.. children.OrderBy(f =>
+            f.SourceEntry.Id is { } id && definitionOrder.TryGetValue(id, out var idx) ? idx : int.MaxValue)];
+    }
+
+    /// <summary>
     /// Compares selections by effective name (natural sort), with original entry name as tiebreaker
     /// only when modifiers have changed at least one name.
     /// Returns 0 for equal names to preserve insertion order (FIFO) when used with a stable sort.

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
@@ -56,6 +56,7 @@ internal static class ConstraintEvaluator
 
             ValidateForceEntryConstraints();
             ValidateCostLimits();
+            ValidateCostRepeatCycles();
         }
 
         // ──────────────────────────────────────────────────────────────────
@@ -112,6 +113,47 @@ internal static class ConstraintEvaluator
         /// </summary>
         private static string? GetRosterCostTypeId(RosterCostSymbol rosterCost) =>
             rosterCost.CostType is IErrorSymbol ? null : rosterCost.CostType.Id;
+
+        // ──────────────────────────────────────────────────────────────────
+        //  Cost repeat cycle validation
+        // ──────────────────────────────────────────────────────────────────
+
+        private void ValidateCostRepeatCycles()
+        {
+            // Delegate cycle detection to ModifierEvaluator which already computed it
+            // during effective cost evaluation. One diagnostic per distinct cycle group.
+            var cycleGroups = _effectiveCache.Evaluator.GetCostRepeatCycleGroups();
+            if (cycleGroups.Count == 0)
+                return;
+
+            // Determine which cycle groups are actually present in the roster
+            // (at least one participating selection must exist).
+            var presentEntryIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var force in _roster.Forces)
+            {
+                foreach (var sel in FlattenSelections(force.ChildSelections))
+                {
+                    if (sel.SourceEntry?.Id is { } id)
+                        presentEntryIds.Add(id);
+                }
+            }
+
+            foreach (var group in cycleGroups)
+            {
+                // Only emit a diagnostic if this cycle is actually present in the roster.
+                bool present = false;
+                foreach (var id in group)
+                {
+                    if (presentEntryIds.Contains(id)) { present = true; break; }
+                }
+                if (!present) continue;
+
+                // Use the smallest ID as the canonical representative to get a stable diagnostic.
+                var representative = group.Min()!;
+                _diagnostics.Add(ErrorCode.WRN_CostRepeatCycle, Location.None,
+                    "selection", representative, representative, "");
+            }
+        }
 
         // ──────────────────────────────────────────────────────────────────
         //  Force entry constraints (field=forces)
@@ -367,9 +409,10 @@ internal static class ConstraintEvaluator
             }
 
             // Validate child selection constraints
+            var forceScopeChecked = new HashSet<(string entryId, string constraintId)>();
             foreach (var sel in force.ChildSelections)
             {
-                ValidateChildConstraints(sel, force);
+                ValidateChildConstraints(sel, force, forceScopeChecked);
             }
 
             // Validate category constraints
@@ -378,7 +421,8 @@ internal static class ConstraintEvaluator
 
         private void ValidateChildConstraints(
             SelectionSymbol parent,
-            ForceSymbol force)
+            ForceSymbol force,
+            HashSet<(string entryId, string constraintId)> forceScopeChecked)
         {
             // Count children by entry ID and entry group ID.
             // For collective children, use per-model counts (divide by parent's number).
@@ -416,15 +460,27 @@ internal static class ConstraintEvaluator
                 {
                     var query = constraint.Query;
                     if (query.ValueKind != QueryValueKind.SelectionCount) continue;
-                    if (query.ScopeKind != QueryScopeKind.Parent) continue;
 
                     var constraintId = constraint.Id ?? "";
-                    var constraintValue = effectiveChildValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
-                    var count = counts.GetValueOrDefault(new CountKey(childEntryId, CountKeyKind.Entry));
 
-                    CheckConstraint(query.Comparison, constraintValue, count,
-                        childEntryId, "selection", parent.EntryId ?? "",
-                        constraintId);
+                    if (query.ScopeKind == QueryScopeKind.Parent)
+                    {
+                        var constraintValue = effectiveChildValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
+                        var count = counts.GetValueOrDefault(new CountKey(childEntryId, CountKeyKind.Entry));
+                        CheckConstraint(query.Comparison, constraintValue, count,
+                            childEntryId, "selection", parent.EntryId ?? "",
+                            constraintId);
+                    }
+                    else if (query.ScopeKind is QueryScopeKind.ContainingForce or QueryScopeKind.ContainingRoster
+                          && forceScopeChecked.Add((childEntryId, constraintId)))
+                    {
+                        // Force/roster-scope constraint on a nested entry — evaluate once per force
+                        var constraintValue = effectiveChildValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
+                        var count = CountSelectionsInScope(query, childEntryId, force);
+                        CheckConstraint(query.Comparison, constraintValue, count,
+                            childEntryId, "selection", childEntryId,
+                            constraintId);
+                    }
                 }
             }
 
@@ -460,13 +516,25 @@ internal static class ConstraintEvaluator
                     {
                         var query = constraint.Query;
                         if (query.ValueKind != QueryValueKind.SelectionCount) continue;
-                        if (query.ScopeKind != QueryScopeKind.Parent) continue;
 
                         var constraintId = constraint.Id ?? "";
-                        var constraintValue = effectiveAvailValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
-                        CheckConstraint(query.Comparison, constraintValue, currentCount,
-                            childId, "selection", parentEntryIdForLookup,
-                            constraintId);
+
+                        if (query.ScopeKind == QueryScopeKind.Parent)
+                        {
+                            var constraintValue = effectiveAvailValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
+                            CheckConstraint(query.Comparison, constraintValue, currentCount,
+                                childId, "selection", parentEntryIdForLookup,
+                                constraintId);
+                        }
+                        else if (query.ScopeKind is QueryScopeKind.ContainingForce or QueryScopeKind.ContainingRoster
+                              && forceScopeChecked.Add((childId, constraintId)))
+                        {
+                            var constraintValue = effectiveAvailValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
+                            var count = CountSelectionsInScope(query, childId, force);
+                            CheckConstraint(query.Comparison, constraintValue, count,
+                                childId, "selection", childId,
+                                constraintId);
+                        }
                     }
                 }
             }
@@ -474,7 +542,7 @@ internal static class ConstraintEvaluator
             // Recurse
             foreach (var child in parent.ChildSelections)
             {
-                ValidateChildConstraints(child, force);
+                ValidateChildConstraints(child, force, forceScopeChecked);
             }
         }
 
@@ -535,14 +603,15 @@ internal static class ConstraintEvaluator
 
         private decimal CountSelectionsInScope(IQuerySymbol query, string targetId, ForceSymbol force)
         {
-            bool includeChildren = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descSel = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descForce = query.Options.HasFlag(QueryOptions.IncludeDescendantForces);
             var selections = query.ScopeKind switch
             {
                 QueryScopeKind.Parent or QueryScopeKind.ContainingForce =>
-                    includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetForceSelections(force, descSel, descForce),
                 QueryScopeKind.ContainingRoster =>
-                    includeChildren ? AllSelectionsFlattened() : AllTopLevelSelections(),
-                _ => includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetRosterSelections(descSel, descForce),
+                _ => GetForceSelections(force, descSel, descForce),
             };
 
             decimal count = 0;
@@ -568,14 +637,15 @@ internal static class ConstraintEvaluator
                     matchIds.Add(lid);
             }
 
-            bool includeChildren = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descSel = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descForce = query.Options.HasFlag(QueryOptions.IncludeDescendantForces);
             var selections = query.ScopeKind switch
             {
                 QueryScopeKind.Parent or QueryScopeKind.ContainingForce =>
-                    includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetForceSelections(force, descSel, descForce),
                 QueryScopeKind.ContainingRoster =>
-                    includeChildren ? AllSelectionsFlattened() : AllTopLevelSelections(),
-                _ => includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetRosterSelections(descSel, descForce),
+                _ => GetForceSelections(force, descSel, descForce),
             };
 
             decimal count = 0;
@@ -589,17 +659,18 @@ internal static class ConstraintEvaluator
 
         private decimal CountCostInScope(IQuerySymbol query, string targetId, ForceSymbol force)
         {
-            bool includeChildren = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descSel = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descForce = query.Options.HasFlag(QueryOptions.IncludeDescendantForces);
             var costTypeId = query.ValueTypeSymbol?.Id;
             if (costTypeId is null) return 0m;
 
             var selections = query.ScopeKind switch
             {
                 QueryScopeKind.Parent or QueryScopeKind.ContainingForce =>
-                    includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetForceSelections(force, descSel, descForce),
                 QueryScopeKind.ContainingRoster =>
-                    includeChildren ? AllSelectionsFlattened() : AllTopLevelSelections(),
-                _ => includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetRosterSelections(descSel, descForce),
+                _ => GetForceSelections(force, descSel, descForce),
             };
 
             decimal sum = 0;
@@ -618,14 +689,15 @@ internal static class ConstraintEvaluator
 
         private decimal CountTotalSelectionsInScope(IQuerySymbol query, ForceSymbol force)
         {
-            bool includeChildren = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descSel = query.Options.HasFlag(QueryOptions.IncludeDescendantSelections);
+            bool descForce = query.Options.HasFlag(QueryOptions.IncludeDescendantForces);
             var selections = query.ScopeKind switch
             {
                 QueryScopeKind.Parent or QueryScopeKind.ContainingForce =>
-                    includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetForceSelections(force, descSel, descForce),
                 QueryScopeKind.ContainingRoster =>
-                    includeChildren ? AllSelectionsFlattened() : AllTopLevelSelections(),
-                _ => includeChildren ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force),
+                    GetRosterSelections(descSel, descForce),
+                _ => GetForceSelections(force, descSel, descForce),
             };
 
             decimal count = 0;
@@ -641,6 +713,31 @@ internal static class ConstraintEvaluator
 
         private IEnumerable<SelectionSymbol> AllSelectionsFlattened() =>
             _roster.Forces.SelectMany(f => FlattenSelections(f.ChildSelections));
+
+        private static IEnumerable<SelectionSymbol> GetForceSelections(
+            ForceSymbol force, bool descSel, bool descForce)
+        {
+            var top = descSel ? FlattenSelections(force.ChildSelections) : TopLevelSelections(force);
+            foreach (var sel in top)
+                yield return sel;
+            if (descForce)
+            {
+                foreach (var child in force.Forces)
+                {
+                    foreach (var sel in GetForceSelections(child, descSel, descForce))
+                        yield return sel;
+                }
+            }
+        }
+
+        private IEnumerable<SelectionSymbol> GetRosterSelections(bool descSel, bool descForce)
+        {
+            foreach (var force in _roster.Forces)
+            {
+                foreach (var sel in GetForceSelections(force, descSel, descForce))
+                    yield return sel;
+            }
+        }
 
         private static int CountSelectionsInForce(string entryId, ForceSymbol force)
         {

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/ConstraintEvaluator.cs
@@ -149,7 +149,7 @@ internal static class ConstraintEvaluator
                 if (!present) continue;
 
                 // Use the smallest ID as the canonical representative to get a stable diagnostic.
-                var representative = group.Min()!;
+                var representative = group.Min(StringComparer.Ordinal)!;
                 _diagnostics.Add(ErrorCode.WRN_CostRepeatCycle, Location.None,
                     "selection", representative, representative, "");
             }
@@ -409,7 +409,7 @@ internal static class ConstraintEvaluator
             }
 
             // Validate child selection constraints
-            var forceScopeChecked = new HashSet<(string entryId, string constraintId)>();
+            var forceScopeChecked = new HashSet<(string entryId, IConstraintSymbol constraint)>();
             foreach (var sel in force.ChildSelections)
             {
                 ValidateChildConstraints(sel, force, forceScopeChecked);
@@ -422,7 +422,7 @@ internal static class ConstraintEvaluator
         private void ValidateChildConstraints(
             SelectionSymbol parent,
             ForceSymbol force,
-            HashSet<(string entryId, string constraintId)> forceScopeChecked)
+            HashSet<(string entryId, IConstraintSymbol constraint)> forceScopeChecked)
         {
             // Count children by entry ID and entry group ID.
             // For collective children, use per-model counts (divide by parent's number).
@@ -461,10 +461,9 @@ internal static class ConstraintEvaluator
                     var query = constraint.Query;
                     if (query.ValueKind != QueryValueKind.SelectionCount) continue;
 
-                    var constraintId = constraint.Id ?? "";
-
                     if (query.ScopeKind == QueryScopeKind.Parent)
                     {
+                        var constraintId = constraint.Id ?? "";
                         var constraintValue = effectiveChildValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
                         var count = counts.GetValueOrDefault(new CountKey(childEntryId, CountKeyKind.Entry));
                         CheckConstraint(query.Comparison, constraintValue, count,
@@ -472,9 +471,10 @@ internal static class ConstraintEvaluator
                             constraintId);
                     }
                     else if (query.ScopeKind is QueryScopeKind.ContainingForce or QueryScopeKind.ContainingRoster
-                          && forceScopeChecked.Add((childEntryId, constraintId)))
+                          && forceScopeChecked.Add((childEntryId, constraint)))
                     {
                         // Force/roster-scope constraint on a nested entry — evaluate once per force
+                        var constraintId = constraint.Id ?? "";
                         var constraintValue = effectiveChildValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
                         var count = CountSelectionsInScope(query, childEntryId, force);
                         CheckConstraint(query.Comparison, constraintValue, count,
@@ -517,18 +517,18 @@ internal static class ConstraintEvaluator
                         var query = constraint.Query;
                         if (query.ValueKind != QueryValueKind.SelectionCount) continue;
 
-                        var constraintId = constraint.Id ?? "";
-
                         if (query.ScopeKind == QueryScopeKind.Parent)
                         {
+                            var constraintId = constraint.Id ?? "";
                             var constraintValue = effectiveAvailValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
                             CheckConstraint(query.Comparison, constraintValue, currentCount,
                                 childId, "selection", parentEntryIdForLookup,
                                 constraintId);
                         }
                         else if (query.ScopeKind is QueryScopeKind.ContainingForce or QueryScopeKind.ContainingRoster
-                              && forceScopeChecked.Add((childId, constraintId)))
+                              && forceScopeChecked.Add((childId, constraint)))
                         {
+                            var constraintId = constraint.Id ?? "";
                             var constraintValue = effectiveAvailValues.GetValueOrDefault(constraintId, query.ReferenceValue ?? 0m);
                             var count = CountSelectionsInScope(query, childId, force);
                             CheckConstraint(query.Comparison, constraintValue, count,

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
@@ -28,11 +28,13 @@ internal sealed class ModifierEvaluator
 {
     private readonly IRosterSymbol _roster;
     private readonly WhamCompilation _compilation;
+    private readonly Lazy<(HashSet<string> CyclicIds, List<HashSet<string>> Groups)> _cycleDetectionLazy;
 
     public ModifierEvaluator(IRosterSymbol roster, WhamCompilation compilation)
     {
         _roster = roster;
         _compilation = compilation;
+        _cycleDetectionLazy = new Lazy<(HashSet<string>, List<HashSet<string>>)>(BuildCostRepeatCycles);
     }
 
     /// <summary>
@@ -1172,21 +1174,21 @@ internal sealed class ModifierEvaluator
     //  Cost-field repeat cycle detection
     // ──────────────────────────────────────────────────────────────────
 
-    private (HashSet<string> CyclicIds, List<HashSet<string>> Groups)? _cycleDetectionResult;
+    // Check repeat children (ModifierEffectBaseSymbol.Effects → RepeatEffectSymbol)
 
     /// <summary>
     /// Returns the set of all entry IDs involved in cost-field repeat cycles.
     /// Entries in this set should have their cyclic cost modifiers skipped.
     /// </summary>
-    public HashSet<string> GetCostRepeatCyclicEntryIds() =>
-        (_cycleDetectionResult ??= BuildCostRepeatCycles()).CyclicIds;
+    public IReadOnlySet<string> GetCostRepeatCyclicEntryIds() =>
+        _cycleDetectionLazy.Value.CyclicIds;
 
     /// <summary>
     /// Returns one group (SCC) per distinct cost-field repeat cycle.
     /// Used by ConstraintEvaluator to emit one diagnostic per cycle.
     /// </summary>
     public IReadOnlyList<HashSet<string>> GetCostRepeatCycleGroups() =>
-        (_cycleDetectionResult ??= BuildCostRepeatCycles()).Groups;
+        _cycleDetectionLazy.Value.Groups;
 
     private (HashSet<string> CyclicIds, List<HashSet<string>> Groups) BuildCostRepeatCycles()
     {

--- a/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
+++ b/src/WarHub.ArmouryModel.Concrete.Extensions/Symbols/Effective/ModifierEvaluator.cs
@@ -1058,6 +1058,15 @@ internal sealed class ModifierEvaluator
             if (referenceValue == 0)
                 return 0;
 
+            // Detect cost-field repeat cycles: if the current entry is involved in a cycle
+            // (its cost-field repeat transitively depends on its own cost), skip the modifier.
+            if (query.ValueKind == QueryValueKind.MemberValue
+                && context.EntrySymbol.Id is { } currentEntryId
+                && GetCostRepeatCyclicEntryIds().Contains(currentEntryId))
+            {
+                return 0;
+            }
+
             var value = CalculateQueryValue(query, context);
 
             // percentValue: scale referenceValue to an absolute threshold
@@ -1158,6 +1167,151 @@ internal sealed class ModifierEvaluator
     private static decimal ParseDecimal(string? value) =>
         decimal.TryParse(value, System.Globalization.NumberStyles.Any,
             System.Globalization.CultureInfo.InvariantCulture, out var result) ? result : 0m;
+
+    // ──────────────────────────────────────────────────────────────────
+    //  Cost-field repeat cycle detection
+    // ──────────────────────────────────────────────────────────────────
+
+    private (HashSet<string> CyclicIds, List<HashSet<string>> Groups)? _cycleDetectionResult;
+
+    /// <summary>
+    /// Returns the set of all entry IDs involved in cost-field repeat cycles.
+    /// Entries in this set should have their cyclic cost modifiers skipped.
+    /// </summary>
+    public HashSet<string> GetCostRepeatCyclicEntryIds() =>
+        (_cycleDetectionResult ??= BuildCostRepeatCycles()).CyclicIds;
+
+    /// <summary>
+    /// Returns one group (SCC) per distinct cost-field repeat cycle.
+    /// Used by ConstraintEvaluator to emit one diagnostic per cycle.
+    /// </summary>
+    public IReadOnlyList<HashSet<string>> GetCostRepeatCycleGroups() =>
+        (_cycleDetectionResult ??= BuildCostRepeatCycles()).Groups;
+
+    private (HashSet<string> CyclicIds, List<HashSet<string>> Groups) BuildCostRepeatCycles()
+    {
+        var deps = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var force in _roster.Forces)
+            CollectCostRepeatDeps(force, deps);
+
+        var sccs = FindCostRepeatSCCs(deps);
+
+        var cyclicIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var scc in sccs)
+            foreach (var id in scc)
+                cyclicIds.Add(id);
+
+        return (cyclicIds, sccs);
+    }
+
+    private static void CollectCostRepeatDeps(IForceSymbol force, Dictionary<string, HashSet<string>> deps)
+    {
+        foreach (var sel in force.Selections)
+            CollectCostRepeatDepsFromSelection(sel, deps);
+        foreach (var child in force.Forces)
+            CollectCostRepeatDeps(child, deps);
+    }
+
+    private static void CollectCostRepeatDepsFromSelection(
+        ISelectionSymbol sel, Dictionary<string, HashSet<string>> deps)
+    {
+        var entryId = sel.SourceEntry?.Id;
+        if (entryId is not null)
+        {
+            foreach (var effect in sel.SourceEntry!.Effects)
+                CollectCostRepeatDepsFromEffect(entryId, effect, deps);
+        }
+        foreach (var child in sel.Selections)
+            CollectCostRepeatDepsFromSelection(child, deps);
+    }
+
+    private static void CollectCostRepeatDepsFromEffect(
+        string ownerEntryId, IEffectSymbol effect, Dictionary<string, HashSet<string>> deps)
+    {
+        // Collect deps from RepetitionQuery with MemberValue — this targets cost fields.
+        // The outer modifier (TargetKind=Member) has children in Effects; those children
+        // are repeat effects (TargetKind=Effect) whose RepetitionQuery carries the filter.
+        if (effect.RepetitionQuery is { ValueKind: QueryValueKind.MemberValue } query
+            && query.FilterSymbol?.Id is { } targetId)
+        {
+            if (!deps.TryGetValue(ownerEntryId, out var set))
+                deps[ownerEntryId] = set = new HashSet<string>(StringComparer.Ordinal);
+            set.Add(targetId);
+        }
+        foreach (var child in effect.Effects)
+            CollectCostRepeatDepsFromEffect(ownerEntryId, child, deps);
+        foreach (var child in effect.ChildrenWhenSatisfied)
+            CollectCostRepeatDepsFromEffect(ownerEntryId, child, deps);
+        foreach (var child in effect.ChildrenWhenUnsatisfied)
+            CollectCostRepeatDepsFromEffect(ownerEntryId, child, deps);
+    }
+
+    /// <summary>
+    /// Tarjan's SCC algorithm — returns only SCCs that contain cycles
+    /// (size > 1, or a single node with a self-loop).
+    /// </summary>
+    private static List<HashSet<string>> FindCostRepeatSCCs(Dictionary<string, HashSet<string>> deps)
+    {
+        var result = new List<HashSet<string>>();
+        var index = 0;
+        var indexes = new Dictionary<string, int>(StringComparer.Ordinal);
+        var lowlinks = new Dictionary<string, int>(StringComparer.Ordinal);
+        var onStack = new HashSet<string>(StringComparer.Ordinal);
+        var stack = new Stack<string>();
+
+        foreach (var id in deps.Keys)
+        {
+            if (!indexes.ContainsKey(id))
+                TarjanSCC(id, deps, result, ref index, indexes, lowlinks, onStack, stack);
+        }
+        return result;
+    }
+
+    private static void TarjanSCC(
+        string id,
+        Dictionary<string, HashSet<string>> deps,
+        List<HashSet<string>> result,
+        ref int index,
+        Dictionary<string, int> indexes,
+        Dictionary<string, int> lowlinks,
+        HashSet<string> onStack,
+        Stack<string> stack)
+    {
+        indexes[id] = lowlinks[id] = index++;
+        stack.Push(id);
+        onStack.Add(id);
+
+        if (deps.TryGetValue(id, out var targets))
+        {
+            foreach (var target in targets)
+            {
+                if (!indexes.ContainsKey(target))
+                {
+                    TarjanSCC(target, deps, result, ref index, indexes, lowlinks, onStack, stack);
+                    lowlinks[id] = Math.Min(lowlinks[id], lowlinks[target]);
+                }
+                else if (onStack.Contains(target))
+                {
+                    lowlinks[id] = Math.Min(lowlinks[id], indexes[target]);
+                }
+            }
+        }
+
+        if (lowlinks[id] == indexes[id])
+        {
+            var scc = new HashSet<string>(StringComparer.Ordinal);
+            while (true)
+            {
+                var w = stack.Pop();
+                onStack.Remove(w);
+                scc.Add(w);
+                if (w == id) break;
+            }
+            // Only report SCCs with actual cycles: multi-node SCCs or self-loops
+            if (scc.Count > 1 || (deps.TryGetValue(id, out var t) && t.Contains(id)))
+                result.Add(scc);
+        }
+    }
 
     /// <summary>
     /// Evaluation context: runtime information about where the evaluation is happening.

--- a/src/WarHub.ArmouryModel.RosterEngine.Spec/StateMapper.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine.Spec/StateMapper.cs
@@ -304,7 +304,7 @@ internal sealed class StateMapper
     private List<ForceState> MapChildForces(IForceSymbol force, IReadOnlyDictionary<string, string> costTypeNames)
     {
         var childForces = new List<ForceState>(force.Forces.Length);
-        foreach (var child in force.Forces)
+        foreach (var child in SelectionOrdering.GetSortedChildForces(force))
         {
             childForces.Add(MapForce(child, costTypeNames));
         }
@@ -330,16 +330,11 @@ internal sealed class StateMapper
                 TypeId: typeId,
                 Value: cost.Value * selectedCount));
         }
-        // BattleScribe emits all referenced cost types on every selection, filling 0 for missing ones
+        // Zero-fill cost types that weren't declared on this entry (BattleScribe convention)
         foreach (var (typeId, name) in costTypeNames)
         {
             if (!emittedTypeIds.Contains(typeId))
-            {
-                costs.Add(new CostState(
-                    Name: name,
-                    TypeId: typeId,
-                    Value: 0));
-            }
+                costs.Add(new CostState(Name: name, TypeId: typeId, Value: 0));
         }
         return costs;
     }

--- a/src/WarHub.ArmouryModel.RosterEngine.Spec/StateMapper.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine.Spec/StateMapper.cs
@@ -36,19 +36,10 @@ internal sealed class StateMapper
             }
         }
 
-        // Build cost type ID → name map for filling missing costs on selections
-        var costTypeNames = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var rosterCost in _roster.Costs)
-        {
-            var typeId = rosterCost.CostType.Id!;
-            if (referencedCostTypeIds.Contains(typeId))
-                costTypeNames.TryAdd(typeId, rosterCost.Name);
-        }
-
         var forces = new List<ForceState>(_roster.Forces.Length);
         for (int i = 0; i < _roster.Forces.Length; i++)
         {
-            forces.Add(MapForce(_roster.Forces[i], costTypeNames));
+            forces.Add(MapForce(_roster.Forces[i]));
         }
         // Sort forces alphabetically by name (BattleScribe canonical ordering)
         forces.Sort((a, b) => SelectionOrdering.NaturalSort.Compare(a.Name, b.Name));
@@ -67,7 +58,7 @@ internal sealed class StateMapper
             GameSystemName: _roster.ContainingNamespace.RootCatalogue.Name);
     }
 
-    private ForceState MapForce(IForceSymbol force, IReadOnlyDictionary<string, string> costTypeNames)
+    private ForceState MapForce(IForceSymbol force)
     {
         var catalogue = force.CatalogueReference.Catalogue;
         var availableEntryCount = EntryResolver.GetRootEntryCount(catalogue);
@@ -75,7 +66,7 @@ internal sealed class StateMapper
         var selections = new List<SelectionState>(force.Selections.Length);
         foreach (var sel in SelectionOrdering.GetSortedSelections(force))
         {
-            selections.Add(MapSelection(sel, costTypeNames));
+            selections.Add(MapSelection(sel));
         }
 
         var profiles = MapProfiles(force.EffectiveSourceEntry.Resources);
@@ -89,7 +80,7 @@ internal sealed class StateMapper
 
         var categories = MapForceCategories(force);
         var publications = MapPublications(force);
-        var childForces = MapChildForces(force, costTypeNames);
+        var childForces = MapChildForces(force);
 
         return new ForceState(
             Id: force.Id,
@@ -113,17 +104,17 @@ internal sealed class StateMapper
         };
     }
 
-    private SelectionState MapSelection(ISelectionSymbol sel, IReadOnlyDictionary<string, string> costTypeNames)
+    private SelectionState MapSelection(ISelectionSymbol sel)
     {
         var children = new List<SelectionState>(sel.Selections.Length);
         foreach (var child in SelectionOrdering.GetSortedChildSelections(sel))
         {
-            children.Add(MapSelection(child, costTypeNames));
+            children.Add(MapSelection(child));
         }
 
         var eff = sel.EffectiveSourceEntry;
 
-        var costs = MapSelectionCosts(eff, sel.SelectedCount, costTypeNames);
+        var costs = MapSelectionCosts(eff, sel.SelectedCount);
         var categories = MapSelectionCategories(eff);
         var profiles = MapProfiles(eff.Resources);
         var rules = MapRules(eff.Resources);
@@ -301,12 +292,12 @@ internal sealed class StateMapper
     //  Child force mapping
     // ──────────────────────────────────────────────────────────────────
 
-    private List<ForceState> MapChildForces(IForceSymbol force, IReadOnlyDictionary<string, string> costTypeNames)
+    private List<ForceState> MapChildForces(IForceSymbol force)
     {
         var childForces = new List<ForceState>(force.Forces.Length);
         foreach (var child in SelectionOrdering.GetSortedChildForces(force))
         {
-            childForces.Add(MapForce(child, costTypeNames));
+            childForces.Add(MapForce(child));
         }
         return childForces;
     }
@@ -316,25 +307,15 @@ internal sealed class StateMapper
     // ──────────────────────────────────────────────────────────────────
 
     private static List<CostState> MapSelectionCosts(
-        ISelectionEntryContainerSymbol eff, int selectedCount,
-        IReadOnlyDictionary<string, string> costTypeNames)
+        ISelectionEntryContainerSymbol eff, int selectedCount)
     {
         var costs = new List<CostState>(eff.Costs.Length);
-        var emittedTypeIds = new HashSet<string>(StringComparer.Ordinal);
         foreach (var cost in eff.Costs)
         {
-            var typeId = cost.Type!.Id!;
-            emittedTypeIds.Add(typeId);
             costs.Add(new CostState(
                 Name: cost.Name,
-                TypeId: typeId,
+                TypeId: cost.Type!.Id!,
                 Value: cost.Value * selectedCount));
-        }
-        // Zero-fill cost types that weren't declared on this entry (BattleScribe convention)
-        foreach (var (typeId, name) in costTypeNames)
-        {
-            if (!emittedTypeIds.Contains(typeId))
-                costs.Add(new CostState(Name: name, TypeId: typeId, Value: 0));
         }
         return costs;
     }

--- a/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
+++ b/src/WarHub.ArmouryModel.RosterEngine/WhamRosterEngine.cs
@@ -727,7 +727,7 @@ public sealed class WhamRosterEngine
         {
             var scaledChildNumber = child.Number * newNumber / oldNumber;
             if (scaledChildNumber < 1) scaledChildNumber = 1;
-            var scaledChild = child.WithNumber(scaledChildNumber);
+            var scaledChild = child.WithUpdatedNumberAndCosts(scaledChildNumber);
             // Recurse into grandchildren
             scaledChild = ScaleChildSelections(scaledChild, child.Number, scaledChildNumber);
             newChildren.Add(scaledChild);
@@ -1277,7 +1277,7 @@ public sealed class WhamRosterEngine
                 if (newNumber > 0)
                 {
                     var newSelNode = ScaleChildSelections(selNode, selNode.Number, newNumber)
-                        .WithNumber(newNumber);
+                        .WithUpdatedNumberAndCosts(newNumber);
                     var newRoster = roster.Replace(selNode, _ => newSelNode).WithUpdatedCostTotals();
                     return state.ReplaceRoster(newRoster);
                 }
@@ -1350,7 +1350,7 @@ public sealed class WhamRosterEngine
 
         // Scale children proportionally when the number changes.
         var newSelNode = ScaleChildSelections(selNode, oldNumber, actualNumber)
-            .WithNumber(actualNumber);
+            .WithUpdatedNumberAndCosts(actualNumber);
         var newRoster = roster.Replace(selNode, _ => newSelNode).WithUpdatedCostTotals();
         return state.ReplaceRoster(newRoster);
     }


### PR DESCRIPTION
## Summary

Bumps `lib/battlescribe-spec` from `aa18776` to `e40d06c` and makes wham conform to all new and modified specs.

## Spec changes (upstream `aa18776` → `e40d06c`)

- **New spec category `ordering/`** (5 specs): canonical selection/force ordering
- **New `modifier/modifier-repeat-cost-*.yaml`** (4 specs): cost-field repeat cycle detection and cost-field repeat after `setSelectionCount`
- **New `condition/condition-include-child-selections.yaml`**: `includeChildSelections` scope counting
- **~100 modified specs**: adjusted expectations across many categories
- **TestKit**: strict "exact count" check for costs — now fails if engine returns more costs than expected
- **`#231`**: `protocol-kitchen-sink` step-43 DEFAULT made engine-neutral for zero-fill costs; `battlescribe:` override carries zero-fill
- **`#232`**: BattleScribe adapter aligns with UI behavior; `modifier-repeat-cost-field` extended with `setSelectionCount` steps

## Implementation changes

### `feat: sort child forces by definition order` (`SelectionOrdering.cs`)
Adds `GetSortedChildForces(IForceSymbol)` that sorts child forces by catalogue definition order, used by `StateMapper.MapChildForces`.

### `fix: includeChildSelections/Forces and nested force-scope constraints` (`ConstraintEvaluator.cs`)
- `GetForceSelections`/`GetRosterSelections` now respect both `IncludeDescendantSelections` and `IncludeDescendantForces` flags
- `ValidateChildConstraints` now evaluates `scope=force` / `scope=roster` constraints on nested entries (previously only `scope=parent` was handled), with per-force deduplication

### `fix: cost-field repeat cycle detection via Tarjan SCC` (`ModifierEvaluator.cs`, `ErrorCode.cs`, `ErrorFacts.cs`)
Adds cycle detection for `modifier-repeat-cost-*` specs. Entries involved in cost-field repeat cycles (A→A self-reference or A→B→A mutual reference) have their repeat skipped, leaving costs at their base value. Reports `WRN_CostRepeatCycle` diagnostics.

### `fix: remove BattleScribe-specific zero-fill from StateMapper` (`StateMapper.cs`)
Removed the zero-fill loop that was emitting `CostState` entries with `Value: 0` for all game-system cost types not declared on an entry. Zero-fill is BattleScribe-specific behavior; wham should not fabricate cost entries. The upstream spec was fixed in `#231` to not require zero-fill from non-BattleScribe engines.

### `fix: scale selection costs when changing count` (`WhamRosterEngine.cs`)
`SetSelectionCountById` and `ScaleChildSelections` were updating `Number` but not the stored `CostNode.Value` in `SelectionNode`. Since costs are stored as totals (unit cost × count), changing count must scale costs proportionally. Fixes cost-field repeat modifiers after `setSelectionCount` operations.

### `fix: thread safety, encapsulation, and correctness in evaluators` (`ModifierEvaluator.cs`, `ConstraintEvaluator.cs`)
- `_cycleDetectionResult`: replaced nullable struct field with `Lazy<T>` for thread-safe lazy initialization
- `GetCostRepeatCyclicEntryIds()`: return type narrowed to `IReadOnlySet<string>` to prevent caller mutation
- `group.Min()`: changed to `group.Min(StringComparer.Ordinal)` for deterministic, culture-independent output
- `forceScopeChecked`: key changed from `(entryId, constraintId)` to `(entryId, IConstraintSymbol)` — prevents collisions when `constraint.Id` is null

## Test results

```
Passed! - Failed: 0, Passed: 362, Skipped: 0, Total: 362 (conformance)
Passed! - all other test projects (no regressions)
```