### PR TITLE
feat: model NewRecruit schema additions over BattleScribe v2.03

### DIFF
--- a/src/WarHub.ArmouryModel.Source.CodeGeneration/WhamSerializerGenerator.Writes.cs
+++ b/src/WarHub.ArmouryModel.Source.CodeGeneration/WhamSerializerGenerator.Writes.cs
@@ -90,7 +90,17 @@ namespace WarHub.ArmouryModel.Source.CodeGeneration
                     var n = attribute.Xml.ElementNameLiteralExpression;
                     var ns = attribute.Xml.NamespaceLiteralExpression;
                     var value = TransformToString(attribute);
-                    yield return "WriteAttribute".Invoke(n, ns, value).AsStatement();
+                    var writeStatement = "WriteAttribute".Invoke(n, ns, value).AsStatement();
+                    // An attribute carrying [DefaultValue(x)] is omitted when it equals x, so data that
+                    // predates the attribute (e.g. original BattleScribe vs NewRecruit additions)
+                    // round-trips without gaining the attribute. WriteAttribute already skips null,
+                    // so this only matters for non-nullable value types like bool.
+                    var defaultValue = GetDefaultValueExpression(attribute);
+                    yield return defaultValue is null
+                        ? writeStatement
+                        : IfStatement(
+                            o.Dot(attribute.IdentifierName).OpNotEquals(defaultValue),
+                            writeStatement);
                 }
                 var textCount = elements.Count(x => x.Xml.Kind == XmlNodeKind.TextContent);
                 if (textCount > 0 && (textCount > 1 || elements.Count() > 1))
@@ -167,6 +177,27 @@ namespace WarHub.ArmouryModel.Source.CodeGeneration
                     yield return "WriteEndElement".Invoke().AsStatement();
                 }
             }
+        }
+
+        // If the attribute property carries [DefaultValue(x)], return a literal for x so the writer can
+        // omit the attribute when it holds that value; otherwise null (always write). Only constants the
+        // generator can render as a literal are honored; anything else falls back to always-write.
+        private ExpressionSyntax? GetDefaultValueExpression(CoreChildBase attribute)
+        {
+            if (DefaultValueSymbol is null)
+                return null;
+            var defaultAttribute = attribute.Symbol
+                .GetAttributes()
+                .FirstOrDefault(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, DefaultValueSymbol));
+            if (defaultAttribute is not { ConstructorArguments: { Length: 1 } })
+                return null;
+            return defaultAttribute.ConstructorArguments[0].Value switch
+            {
+                bool b => LiteralExpression(b ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression),
+                string s => LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(s)),
+                int i => LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(i)),
+                _ => null
+            };
         }
 
         private ExpressionSyntax CreateWriteEnumCall(ITypeSymbol enumSymbol, ExpressionSyntax value)

--- a/src/WarHub.ArmouryModel.Source.CodeGeneration/WhamSerializerGenerator.cs
+++ b/src/WarHub.ArmouryModel.Source.CodeGeneration/WhamSerializerGenerator.cs
@@ -16,6 +16,7 @@ namespace WarHub.ArmouryModel.Source.CodeGeneration
         private const string WhamCoreXmlSerializationReaderName = "WhamCoreXmlSerializationReader";
         private const string WhamCoreXmlSerializationWriterName = "WhamCoreXmlSerializationWriter";
         private const string XmlEnumAttributeMetadataName = "System.Xml.Serialization.XmlEnumAttribute";
+        private const string DefaultValueAttributeMetadataName = "System.ComponentModel.DefaultValueAttribute";
 
         public WhamSerializerGenerator(Compilation compilation, ImmutableArray<CoreDescriptor> descriptors)
         {
@@ -24,6 +25,7 @@ namespace WarHub.ArmouryModel.Source.CodeGeneration
             SealedCores = descriptors.Where(x => x.TypeSymbol.IsSealed).ToImmutableArray();
             RootCores = SealedCores.Where(x => x.Xml.IsRoot).ToImmutableArray();
             XmlEnumSymbol = Compilation.GetTypeByMetadataNameOrThrow(XmlEnumAttributeMetadataName);
+            DefaultValueSymbol = Compilation.GetTypeByMetadataName(DefaultValueAttributeMetadataName);
         }
 
         public Compilation Compilation { get; }
@@ -31,6 +33,7 @@ namespace WarHub.ArmouryModel.Source.CodeGeneration
         public ImmutableArray<CoreDescriptor> SealedCores { get; }
         public ImmutableArray<CoreDescriptor> RootCores { get; }
         private INamedTypeSymbol XmlEnumSymbol { get; }
+        private INamedTypeSymbol? DefaultValueSymbol { get; }
 
         private static ImmutableArray<string> DisabledErrorCodes { get; } =
             new[]

--- a/src/WarHub.ArmouryModel.Source/AssociationCore.cs
+++ b/src/WarHub.ArmouryModel.Source/AssociationCore.cs
@@ -1,0 +1,29 @@
+using System.Xml.Serialization;
+
+namespace WarHub.ArmouryModel.Source
+{
+    /// <summary>
+    /// NewRecruit addition: an association relates a selection to a number (min/max) of other
+    /// selections resolved by a query (scope/field/childId), inheriting the query attributes from
+    /// <see cref="QueryBaseCore" />. Not present in original BattleScribe v2.03.
+    /// </summary>
+    [WhamNodeCore]
+    [XmlType("association")]
+    public sealed partial record AssociationCore : QueryBaseCore
+    {
+        [XmlAttribute("id")]
+        public string? Id { get; init; }
+
+        [XmlAttribute("name")]
+        public string? Name { get; init; }
+
+        [XmlAttribute("min")]
+        public int Min { get; init; }
+
+        [XmlAttribute("max")]
+        public int Max { get; init; }
+
+        [XmlAttribute("childId")]
+        public string? ChildId { get; init; }
+    }
+}

--- a/src/WarHub.ArmouryModel.Source/AttributeTypeCore.cs
+++ b/src/WarHub.ArmouryModel.Source/AttributeTypeCore.cs
@@ -1,0 +1,20 @@
+using System.Xml.Serialization;
+
+namespace WarHub.ArmouryModel.Source
+{
+    /// <summary>
+    /// NewRecruit addition: an attribute type on a profile type (parallel to
+    /// <see cref="CharacteristicTypeCore" />), used to carry export-only data. Not present in
+    /// original BattleScribe v2.03.
+    /// </summary>
+    [WhamNodeCore]
+    [XmlType("attributeType")]
+    public sealed partial record AttributeTypeCore : CommentableCore
+    {
+        [XmlAttribute("id")]
+        public string? Id { get; init; }
+
+        [XmlAttribute("name")]
+        public string? Name { get; init; }
+    }
+}

--- a/src/WarHub.ArmouryModel.Source/CatalogueBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/CatalogueBaseCore.cs
@@ -71,5 +71,12 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlArray("sharedInfoGroups")]
         public ImmutableArray<InfoGroupCore> SharedInfoGroups { get; init; } = ImmutableArray<InfoGroupCore>.Empty;
+
+        // NewRecruit additions.
+        [XmlArray("sharedForceEntries")]
+        public ImmutableArray<ForceEntryCore> SharedForceEntries { get; init; } = ImmutableArray<ForceEntryCore>.Empty;
+
+        [XmlArray("sharedAssociations")]
+        public ImmutableArray<AssociationCore> SharedAssociations { get; init; } = ImmutableArray<AssociationCore>.Empty;
     }
 }

--- a/src/WarHub.ArmouryModel.Source/CharacteristicTypeCore.cs
+++ b/src/WarHub.ArmouryModel.Source/CharacteristicTypeCore.cs
@@ -11,5 +11,12 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlAttribute("name")]
         public string? Name { get; init; }
+
+        // NewRecruit additions. (KindValue avoids colliding with SourceNode.Kind.)
+        [XmlAttribute("kind")]
+        public string? KindValue { get; init; }
+
+        [XmlAttribute("defaultValue")]
+        public string? DefaultValue { get; init; }
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ConditionGroupKind.cs
+++ b/src/WarHub.ArmouryModel.Source/ConditionGroupKind.cs
@@ -8,6 +8,55 @@ namespace WarHub.ArmouryModel.Source
         And,
 
         [XmlEnum("or")]
-        Or
+        Or,
+
+        // NewRecruit additions: boolean, numeric, and comparison group kinds.
+        [XmlEnum("not")]
+        Not,
+
+        [XmlEnum("count")]
+        Count,
+
+        [XmlEnum("add")]
+        Add,
+
+        [XmlEnum("subtract")]
+        Subtract,
+
+        [XmlEnum("multiply")]
+        Multiply,
+
+        [XmlEnum("divide")]
+        Divide,
+
+        [XmlEnum("modulo")]
+        Modulo,
+
+        [XmlEnum("power")]
+        Power,
+
+        [XmlEnum("min")]
+        Min,
+
+        [XmlEnum("max")]
+        Max,
+
+        [XmlEnum("greater")]
+        Greater,
+
+        [XmlEnum("greaterOrEqual")]
+        GreaterOrEqual,
+
+        [XmlEnum("less")]
+        Less,
+
+        [XmlEnum("lessOrEqual")]
+        LessOrEqual,
+
+        [XmlEnum("equal")]
+        Equal,
+
+        [XmlEnum("notEqual")]
+        NotEqual
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ConditionKind.cs
+++ b/src/WarHub.ArmouryModel.Source/ConditionKind.cs
@@ -26,6 +26,16 @@ namespace WarHub.ArmouryModel.Source
         InstanceOf,
 
         [XmlEnum("notInstanceOf")]
-        NotInstanceOf
+        NotInstanceOf,
+
+        // NewRecruit additions.
+        [XmlEnum("always")]
+        Always,
+
+        [XmlEnum("never")]
+        Never,
+
+        [XmlEnum("before")]
+        Before
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ConstraintCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ConstraintCore.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+﻿using System.ComponentModel;
+using System.Xml.Serialization;
 
 namespace WarHub.ArmouryModel.Source
 {
@@ -11,5 +12,18 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlAttribute("type")]
         public ConstraintKind Type { get; init; }
+
+        // NewRecruit additions. DefaultValue keeps them out of serialized output unless set, so
+        // original BattleScribe data (which has neither attribute) round-trips byte-identically.
+        [XmlAttribute("negative")]
+        [DefaultValue(false)]
+        public bool Negative { get; init; }
+
+        [XmlAttribute("automatic")]
+        [DefaultValue(false)]
+        public bool Automatic { get; init; }
+
+        [XmlAttribute("message")]
+        public string? Message { get; init; }
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ConstraintKind.cs
+++ b/src/WarHub.ArmouryModel.Source/ConstraintKind.cs
@@ -8,6 +8,10 @@ namespace WarHub.ArmouryModel.Source
         Minimum,
 
         [XmlEnum("max")]
-        Maximum
+        Maximum,
+
+        // NewRecruit addition.
+        [XmlEnum("exactly")]
+        Exactly
     }
 }

--- a/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
+++ b/src/WarHub.ArmouryModel.Source/Foundation/NodeFactory.cs
@@ -114,7 +114,9 @@ namespace WarHub.ArmouryModel.Source
             return CharacteristicType(
                 comment: null,
                 id: NewId(),
-                name: name ?? NewName());
+                name: name ?? NewName(),
+                kindValue: null,
+                defaultValue: null);
         }
 
         public static ConditionNode Condition(
@@ -162,7 +164,10 @@ namespace WarHub.ArmouryModel.Source
                 includeChildSelections: false,
                 includeChildForces: false,
                 id: id ?? NewId(),
-                type: type);
+                type: type,
+                negative: false,
+                automatic: false,
+                message: null);
         }
 
         public static CostNode Cost(CostTypeNode costType, decimal value = 0m)
@@ -405,7 +410,8 @@ namespace WarHub.ArmouryModel.Source
             return ProfileType(
                 comment: null,
                 id: NewId(),
-                name: name ?? NewName());
+                name: name ?? NewName(),
+                kindValue: null);
         }
 
         public static PublicationNode Publication(string? name = null)

--- a/src/WarHub.ArmouryModel.Source/Foundation/SourceKind.cs
+++ b/src/WarHub.ArmouryModel.Source/Foundation/SourceKind.cs
@@ -42,6 +42,13 @@
 
         Repeat, RepeatList,
 
+        // NewRecruit additions
+        Association, AssociationList,
+
+        AttributeType, AttributeTypeList,
+
+        LocalConditionGroup, LocalConditionGroupList,
+
         // infos
         Characteristic, CharacteristicList,
 

--- a/src/WarHub.ArmouryModel.Source/LocalConditionGroupCore.cs
+++ b/src/WarHub.ArmouryModel.Source/LocalConditionGroupCore.cs
@@ -1,0 +1,21 @@
+using System.Xml.Serialization;
+
+namespace WarHub.ArmouryModel.Source
+{
+    /// <summary>
+    /// NewRecruit addition: a local condition group is a child of a modifier carrying its own
+    /// query (inherited from <see cref="QueryFilteredBaseCore" />), a condition <see cref="Type" />,
+    /// and a repeat count. Distinct from the baseline <see cref="ConditionGroupCore" />. Not present
+    /// in original BattleScribe v2.03.
+    /// </summary>
+    [WhamNodeCore]
+    [XmlType("localConditionGroup")]
+    public sealed partial record LocalConditionGroupCore : QueryFilteredBaseCore
+    {
+        [XmlAttribute("type")]
+        public ConditionKind Type { get; init; }
+
+        [XmlAttribute("repeats")]
+        public int RepeatCount { get; init; }
+    }
+}

--- a/src/WarHub.ArmouryModel.Source/ModifierBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ModifierBaseCore.cs
@@ -14,5 +14,9 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlArray("conditionGroups")]
         public ImmutableArray<ConditionGroupCore> ConditionGroups { get; init; } = ImmutableArray<ConditionGroupCore>.Empty;
+
+        // NewRecruit addition.
+        [XmlArray("localConditionGroups")]
+        public ImmutableArray<LocalConditionGroupCore> LocalConditionGroups { get; init; } = ImmutableArray<LocalConditionGroupCore>.Empty;
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ModifierKind.cs
+++ b/src/WarHub.ArmouryModel.Source/ModifierKind.cs
@@ -58,6 +58,49 @@ namespace WarHub.ArmouryModel.Source
         /// Usable on Category fields.
         /// </summary>
         [XmlEnum("unset-primary")]
-        UnsetPrimary
+        UnsetPrimary,
+
+        // NewRecruit additions: extended numeric operations, string ops, and hide.
+        [XmlEnum("multiply")]
+        Multiply,
+
+        [XmlEnum("divide")]
+        Divide,
+
+        [XmlEnum("modulo")]
+        Modulo,
+
+        [XmlEnum("power")]
+        Power,
+
+        [XmlEnum("exponent")]
+        Exponent,
+
+        [XmlEnum("triangular")]
+        Triangular,
+
+        [XmlEnum("ceil")]
+        Ceil,
+
+        [XmlEnum("floor")]
+        Floor,
+
+        [XmlEnum("cumulative-add")]
+        CumulativeAdd,
+
+        [XmlEnum("cumulative-multiply")]
+        CumulativeMultiply,
+
+        [XmlEnum("cumulative-power")]
+        CumulativePower,
+
+        [XmlEnum("prepend")]
+        Prepend,
+
+        [XmlEnum("replace")]
+        Replace,
+
+        [XmlEnum("hide")]
+        Hide
     }
 }

--- a/src/WarHub.ArmouryModel.Source/ProfileTypeCore.cs
+++ b/src/WarHub.ArmouryModel.Source/ProfileTypeCore.cs
@@ -13,7 +13,15 @@ namespace WarHub.ArmouryModel.Source
         [XmlAttribute("name")]
         public string? Name { get; init; }
 
+        // NewRecruit addition. (Named KindValue to avoid colliding with SourceNode.Kind.)
+        [XmlAttribute("kind")]
+        public string? KindValue { get; init; }
+
         [XmlArray("characteristicTypes")]
         public ImmutableArray<CharacteristicTypeCore> CharacteristicTypes { get; init; } = ImmutableArray<CharacteristicTypeCore>.Empty;
+
+        // NewRecruit addition.
+        [XmlArray("attributeTypes")]
+        public ImmutableArray<AttributeTypeCore> AttributeTypes { get; init; } = ImmutableArray<AttributeTypeCore>.Empty;
     }
 }

--- a/src/WarHub.ArmouryModel.Source/SelectionEntryBaseCore.cs
+++ b/src/WarHub.ArmouryModel.Source/SelectionEntryBaseCore.cs
@@ -23,5 +23,9 @@ namespace WarHub.ArmouryModel.Source
 
         [XmlArray("entryLinks")]
         public ImmutableArray<EntryLinkCore> EntryLinks { get; init; } = ImmutableArray<EntryLinkCore>.Empty;
+
+        // NewRecruit addition.
+        [XmlArray("associations")]
+        public ImmutableArray<AssociationCore> Associations { get; init; } = ImmutableArray<AssociationCore>.Empty;
     }
 }

--- a/src/WarHub.ArmouryModel.Source/SelectionEntryKind.cs
+++ b/src/WarHub.ArmouryModel.Source/SelectionEntryKind.cs
@@ -11,6 +11,16 @@ namespace WarHub.ArmouryModel.Source
         Model,
 
         [XmlEnum("unit")]
-        Unit
+        Unit,
+
+        // NewRecruit additions.
+        [XmlEnum("unit-group")]
+        UnitGroup,
+
+        [XmlEnum("mount")]
+        Mount,
+
+        [XmlEnum("crew")]
+        Crew
     }
 }

--- a/src/dataformat/xml/schema/latest/Catalogue.xsd
+++ b/src/dataformat/xml/schema/latest/Catalogue.xsd
@@ -51,6 +51,9 @@
       <xs:extension base="tns:Commentable">
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />
+        <!--NewRecruit additions-->
+        <xs:attribute name="kind" type="xs:string" />
+        <xs:attribute name="defaultValue" type="xs:string" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -67,11 +70,31 @@
       <xs:extension base="tns:Commentable">
         <xs:sequence>
           <xs:element name="characteristicTypes" type="tns:CharacteristicTypeList" minOccurs="0" />
+          <!--NewRecruit addition-->
+          <xs:element name="attributeTypes" type="tns:AttributeTypeList" minOccurs="0" />
         </xs:sequence>
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />
+        <!--NewRecruit addition-->
+        <xs:attribute name="kind" type="xs:string" />
       </xs:extension>
     </xs:complexContent>
+  </xs:complexType>
+
+  <!--NewRecruit addition: attribute type (parallel to characteristicType)-->
+  <xs:complexType name="AttributeType">
+    <xs:complexContent>
+      <xs:extension base="tns:Commentable">
+        <xs:attribute name="id" type="tns:idtype" />
+        <xs:attribute name="name" type="xs:string" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="AttributeTypeList">
+    <xs:sequence>
+      <xs:element name="attributeType" type="tns:AttributeType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="ProfileTypeList">
@@ -279,6 +302,8 @@
           <xs:element name="selectionEntries" type="tns:SelectionEntryList" minOccurs="0" />
           <xs:element name="selectionEntryGroups" type="tns:SelectionEntryGroupList" minOccurs="0" />
           <xs:element name="entryLinks" type="tns:EntryLinkList" minOccurs="0" />
+          <!--NewRecruit addition-->
+          <xs:element name="associations" type="tns:AssociationList" minOccurs="0" />
         </xs:sequence>
         <xs:attribute name="collective" type="xs:boolean" default="false" />
         <xs:attribute name="import" type="xs:boolean" default="false" />
@@ -309,6 +334,10 @@
       <xs:enumeration value="upgrade"/>
       <xs:enumeration value="model"/>
       <xs:enumeration value="unit"/>
+      <!--NewRecruit additions-->
+      <xs:enumeration value="unit-group"/>
+      <xs:enumeration value="mount"/>
+      <xs:enumeration value="crew"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -433,6 +462,25 @@
     </xs:complexContent>
   </xs:complexType>
   
+  <!--NewRecruit addition: association (a query relating a selection to min/max other selections)-->
+  <xs:complexType name="Association">
+    <xs:complexContent>
+      <xs:extension base="tns:QueryBase">
+        <xs:attribute name="id" type="tns:idtype" />
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="min" type="xs:integer" default="0" />
+        <xs:attribute name="max" type="xs:integer" default="0" />
+        <xs:attribute name="childId" type="tns:idtype" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="AssociationList">
+    <xs:sequence>
+      <xs:element name="association" type="tns:Association" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
   <!--query filtered base-->
   <xs:complexType name="QueryFilteredBase">
     <xs:complexContent>
@@ -448,6 +496,10 @@
       <xs:extension base="tns:QueryBase">
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="type" type="tns:ConstraintKind" use="required" />
+        <!--NewRecruit additions-->
+        <xs:attribute name="negative" type="xs:boolean" default="false" />
+        <xs:attribute name="automatic" type="xs:boolean" default="false" />
+        <xs:attribute name="message" type="xs:string" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -462,6 +514,8 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="min" />
       <xs:enumeration value="max" />
+      <!--NewRecruit addition (NR expands it to a min+max pair on export)-->
+      <xs:enumeration value="exactly" />
     </xs:restriction>
   </xs:simpleType>
 
@@ -473,9 +527,27 @@
           <xs:element name="repeats" type="tns:RepeatList" minOccurs="0" />
           <xs:element name="conditions" type="tns:ConditionList" minOccurs="0" />
           <xs:element name="conditionGroups" type="tns:ConditionGroupList" minOccurs="0" />
+          <!--NewRecruit addition-->
+          <xs:element name="localConditionGroups" type="tns:LocalConditionGroupList" minOccurs="0" />
         </xs:sequence>
       </xs:extension>
     </xs:complexContent>
+  </xs:complexType>
+
+  <!--NewRecruit addition: a modifier's local condition group (own query + condition type + repeat count)-->
+  <xs:complexType name="LocalConditionGroup">
+    <xs:complexContent>
+      <xs:extension base="tns:QueryFilteredBase">
+        <xs:attribute name="type" type="tns:ConditionKind" use="required" />
+        <xs:attribute name="repeats" type="xs:integer" default="0" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="LocalConditionGroupList">
+    <xs:sequence>
+      <xs:element name="localConditionGroup" type="tns:LocalConditionGroup" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
   </xs:complexType>
 
   <!--modifier-->
@@ -505,6 +577,21 @@
       <xs:enumeration value="remove" />
       <xs:enumeration value="set-primary" />
       <xs:enumeration value="unset-primary" />
+      <!--NewRecruit additions (math/string ops, gated on the modified field's data type)-->
+      <xs:enumeration value="multiply" />
+      <xs:enumeration value="divide" />
+      <xs:enumeration value="modulo" />
+      <xs:enumeration value="power" />
+      <xs:enumeration value="exponent" />
+      <xs:enumeration value="triangular" />
+      <xs:enumeration value="ceil" />
+      <xs:enumeration value="floor" />
+      <xs:enumeration value="cumulative-add" />
+      <xs:enumeration value="cumulative-multiply" />
+      <xs:enumeration value="cumulative-power" />
+      <xs:enumeration value="prepend" />
+      <xs:enumeration value="replace" />
+      <xs:enumeration value="hide" />
     </xs:restriction>
   </xs:simpleType>
 
@@ -567,6 +654,10 @@
       <xs:enumeration value="atMost" />
       <xs:enumeration value="instanceOf" />
       <xs:enumeration value="notInstanceOf" />
+      <!--NewRecruit additions ("before" is valid only inside a localConditionGroup)-->
+      <xs:enumeration value="always" />
+      <xs:enumeration value="never" />
+      <xs:enumeration value="before" />
     </xs:restriction>
   </xs:simpleType>
 
@@ -593,6 +684,23 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="and" />
       <xs:enumeration value="or" />
+      <!--NewRecruit additions (a conditionGroup is now also a numeric/comparison expression node)-->
+      <xs:enumeration value="not" />
+      <xs:enumeration value="count" />
+      <xs:enumeration value="add" />
+      <xs:enumeration value="subtract" />
+      <xs:enumeration value="multiply" />
+      <xs:enumeration value="divide" />
+      <xs:enumeration value="modulo" />
+      <xs:enumeration value="power" />
+      <xs:enumeration value="min" />
+      <xs:enumeration value="max" />
+      <xs:enumeration value="greater" />
+      <xs:enumeration value="greaterOrEqual" />
+      <xs:enumeration value="less" />
+      <xs:enumeration value="lessOrEqual" />
+      <xs:enumeration value="equal" />
+      <xs:enumeration value="notEqual" />
     </xs:restriction>
   </xs:simpleType>
 
@@ -711,6 +819,9 @@
           <xs:element name="sharedRules" type="tns:RuleList" minOccurs="0" />
           <xs:element name="sharedProfiles" type="tns:ProfileList" minOccurs="0" />
           <xs:element name="sharedInfoGroups" type="tns:InfoGroupList" minOccurs="0" />
+          <!--NewRecruit additions-->
+          <xs:element name="sharedForceEntries" type="tns:ForceEntryList" minOccurs="0" />
+          <xs:element name="sharedAssociations" type="tns:AssociationList" minOccurs="0" />
         </xs:sequence>
         <xs:attribute name="id" type="tns:idtype" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />

--- a/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/NewRecruitAdditionsTests.cs
+++ b/tests/WarHub.ArmouryModel.Source.Tests/DataFormat/NewRecruitAdditionsTests.cs
@@ -1,0 +1,148 @@
+using System.IO;
+using FluentAssertions;
+using WarHub.ArmouryModel.Source.BattleScribe;
+using Xunit;
+using static WarHub.ArmouryModel.Source.NodeFactory;
+
+namespace WarHub.ArmouryModel.Source.Tests.DataFormat
+{
+    /// <summary>
+    /// NewRecruit extended the BattleScribe data format with new nodes, enum values, and attributes.
+    /// These are modelled in wham as part of the format; the tests assert they (a) validate against the
+    /// schema and (b) survive a serialize → deserialize round-trip.
+    /// </summary>
+    public class NewRecruitAdditionsTests
+    {
+        private static GamesystemNode BuildGamesystemWithAdditions() =>
+            Gamesystem()
+            .AddProfileTypes(
+                ProfileType("ptype")
+                .WithKindValue("Cost")
+                .AddCharacteristicTypes(
+                    CharacteristicType("ctype")
+                    .WithKindValue("Annotation")
+                    .WithDefaultValue("0"))
+                .AddAttributeTypes(
+                    AttributeType(comment: null, id: "atype-1", name: "Attr")))
+            .AddSelectionEntries(
+                SelectionEntry("Squad", "se-1")
+                .WithType(SelectionEntryKind.UnitGroup)
+                .AddConstraints(
+                    Constraint(field: "selections", scope: "parent", value: 1m, id: "con-1", type: ConstraintKind.Exactly)
+                    .WithNegative(true)
+                    .WithAutomatic(true)
+                    .WithMessage("custom message"))
+                .AddAssociations(
+                    Association(
+                        comment: null,
+                        field: "selections",
+                        scope: "parent",
+                        value: 0m,
+                        isValuePercentage: false,
+                        shared: false,
+                        includeChildSelections: false,
+                        includeChildForces: false,
+                        id: "assoc-1",
+                        name: "Bodyguard",
+                        min: 1,
+                        max: 2,
+                        childId: null))
+                .AddModifiers(
+                    Modifier(type: ModifierKind.Multiply, field: "points")
+                    .AddConditionGroups(ConditionGroup(type: ConditionGroupKind.GreaterOrEqual))
+                    .AddLocalConditionGroups(
+                        LocalConditionGroup(
+                            comment: null,
+                            field: "selections",
+                            scope: "parent",
+                            value: 1m,
+                            isValuePercentage: false,
+                            shared: false,
+                            includeChildSelections: false,
+                            includeChildForces: false,
+                            childId: null,
+                            type: ConditionKind.Before,
+                            repeatCount: 1))));
+
+        [Fact]
+        public void NewRecruit_additions_are_schema_validated()
+        {
+            var catalogue =
+                Catalogue(BuildGamesystemWithAdditions())
+                .AddSharedForceEntries(ForceEntry().WithName("Detachment"))
+                .AddSharedAssociations(
+                    Association(
+                        comment: null,
+                        field: "selections",
+                        scope: "force",
+                        value: 0m,
+                        isValuePercentage: false,
+                        shared: false,
+                        includeChildSelections: false,
+                        includeChildForces: false,
+                        id: "assoc-shared",
+                        name: "Warlord",
+                        min: 0,
+                        max: 1,
+                        childId: null));
+
+            var messages = SchemaUtils.Validate(catalogue);
+
+            messages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void NewRecruit_additions_round_trip()
+        {
+            var original = BuildGamesystemWithAdditions();
+            using var stream = new MemoryStream();
+            original.Serialize(stream);
+            stream.Position = 0;
+
+            var gst = stream.DeserializeGamesystem()!;
+
+            var entry = gst.SelectionEntries[0];
+            entry.Type.Should().Be(SelectionEntryKind.UnitGroup);
+
+            var constraint = entry.Constraints[0];
+            constraint.Type.Should().Be(ConstraintKind.Exactly);
+            constraint.Negative.Should().BeTrue();
+            constraint.Automatic.Should().BeTrue();
+            constraint.Message.Should().Be("custom message");
+
+            entry.Associations.Should().ContainSingle()
+                .Which.Min.Should().Be(1);
+
+            var modifier = entry.Modifiers[0];
+            modifier.Type.Should().Be(ModifierKind.Multiply);
+            modifier.ConditionGroups[0].Type.Should().Be(ConditionGroupKind.GreaterOrEqual);
+            modifier.LocalConditionGroups.Should().ContainSingle()
+                .Which.Type.Should().Be(ConditionKind.Before);
+
+            var profileType = gst.ProfileTypes[0];
+            profileType.KindValue.Should().Be("Cost");
+            profileType.AttributeTypes.Should().ContainSingle().Which.Name.Should().Be("Attr");
+            profileType.CharacteristicTypes[0].KindValue.Should().Be("Annotation");
+            profileType.CharacteristicTypes[0].DefaultValue.Should().Be("0");
+        }
+
+        [Fact]
+        public void Default_constraint_flags_are_omitted_from_output()
+        {
+            // negative/automatic carry [DefaultValue(false)], so a constraint that does not set them
+            // serialises without the attributes — original BattleScribe data round-trips unchanged.
+            var gst =
+                Gamesystem()
+                .AddSelectionEntries(
+                    SelectionEntry()
+                    .AddConstraints(Constraint()));
+
+            using var writer = new StringWriter();
+            gst.Serialize(writer);
+            var xml = writer.ToString();
+
+            xml.Should().NotContain("negative=");
+            xml.Should().NotContain("automatic=");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

NewRecruit reimplemented the abandoned BattleScribe data engine and then **evolved** the catalogue/gameSystem data format. This models those additions as part of the format, so downstream tooling (e.g. the BattleScribe conformance spec suite) can treat the NR-superset as the base and exclude only original BattleScribe.

### Model additions
- **Enum values:** `SelectionEntryKind` +`unit-group`/`mount`/`crew`; `ConstraintKind` +`exactly`; `ConditionKind` +`always`/`never`/`before`; `ConditionGroupKind` +the numeric/comparison set (`not`, `count`, `add`…`notEqual`); `ModifierKind` +the math/string ops (`multiply`…`replace`, `hide`).
- **New nodes:** `AssociationCore`, `AttributeTypeCore`, `LocalConditionGroupCore`.
- **New collections:** selectionEntry `associations`; modifier `localConditionGroups`; profileType `attributeTypes`; catalogue-root `sharedForceEntries`/`sharedAssociations`.
- **New attributes:** constraint `negative`/`automatic`/`message`; characteristicType `kind`/`defaultValue`; profileType `kind`.
- `latest/Catalogue.xsd` extended to declare all of the above (the single source XSD that is transformed into the three namespace schemas at build), so the model validates against the schema.

### Serializer fix — preserve BattleScribe round-trip fidelity
The generated writer emits **every** value-type attribute (only nullable strings are skipped at runtime). So `negative`/`automatic` (non-nullable `bool`) would have written `="false"` on every constraint, breaking round-trip with original BattleScribe data that has neither attribute (`ReadWriteCatalogue`/`ReadWriteGamesystem`).

Fix: teach `WhamSerializerGenerator` to honor `[DefaultValue]` — a value-type attribute equal to its declared default is omitted. `negative`/`automatic` carry `[DefaultValue(false)]`, so original BattleScribe data round-trips byte-identically while NewRecruit data still emits them when set.

### Tests
- `NewRecruitAdditionsTests`: schema-validation of a catalogue exercising all new nodes/enums/attributes; a serialize → deserialize round-trip; and a guard that default constraint flags stay out of the output.
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)